### PR TITLE
[#6] FastlaneCore::Helper.is_ci? for detecting CI

### DIFF
--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -55,16 +55,8 @@ module FastlaneCore
 
     # @return true if building in a known CI environment
     def self.is_ci?
-      # Check for Jenkins environment variable
-      if ENV["JENKINS_URL"]
-        return true
-      end
-
-      if ENV["TRAVIS"]
-        return true
-      end
-
-      return false
+      # Check for Jenkins or Travis CI environment variables
+      ENV.has_key?("JENKINS_URL") || ENV.has_key?("TRAVIS")
     end
 
     # @return the full path to the Xcode developer tools of the currently

--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -53,6 +53,20 @@ module FastlaneCore
       self.test?
     end
 
+    # @return true if building in a known CI environment
+    def self.is_ci?
+      # Check for Jenkins environment variable
+      if ENV["JENKINS_URL"]
+        return true
+      end
+
+      if ENV["TRAVIS"]
+        return true
+      end
+
+      return false
+    end
+
     # @return the full path to the Xcode developer tools of the currently
     #  running system
     def self.xcode_path

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -2,6 +2,7 @@ describe FastlaneCore do
   describe FastlaneCore::Helper do
     describe "#is_ci?" do
       it "returns false when not building in a known CI environment" do
+        stub_const('ENV', {})
         expect(FastlaneCore::Helper.is_ci?).to be false
       end
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,0 +1,19 @@
+describe FastlaneCore do
+  describe FastlaneCore::Helper do
+    describe "#is_ci?" do
+      it "returns false when not building in a known CI environment" do
+        expect(FastlaneCore::Helper.is_ci?).to be false
+      end
+
+      it "returns true when building in Jenkins" do
+        stub_const('ENV', { 'JENKINS_URL' => 'http://fake.jenkins.url' })
+        expect(FastlaneCore::Helper.is_ci?).to be true
+      end
+
+      it "returns true when building in Travis CI" do
+        stub_const('ENV', { 'TRAVIS' => true })
+        expect(FastlaneCore::Helper.is_ci?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Supports detection of Jenkins or Travis CI build environment using
environment variables used by each.

See: #6
