### PR TITLE
Update highline dependency

### DIFF
--- a/fastlane_core.gemspec
+++ b/fastlane_core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'json' # Because sometimes it's just not installed
   spec.add_dependency 'multi_json' # Because sometimes it's just not installed
-  spec.add_dependency 'highline', '~> 1.6.21' # user inputs (e.g. passwords)
+  spec.add_dependency 'highline', '~> 1.7.1' # user inputs (e.g. passwords)
   spec.add_dependency 'colored' # coloured terminal output
   spec.add_dependency 'commander', '>= 4.1.0' # CLI parser
   spec.add_dependency 'babosa' # transliterate strings


### PR DESCRIPTION
I'm working on a project which has both fastlane and highline as dependencies. My project requires this fix to highline to be present JEG2/highline/issues/112 and thus uses version 1.7.1. As fastlane's highline gem asks for version '~> 1.6.21' my project won't build.

I'm unsure if asking you to update your dependency is the correct way around this problem. If you know a way that allows me to both use fastlane and highline version 1.7.1 in my project I'm all ears.
