### PR TITLE
Support different location for iTMSTransporter

### DIFF
--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -68,7 +68,12 @@ module FastlaneCore
 
     # @return the full path to the iTMSTransporter executable
     def self.transporter_path
-      self.xcode_path + '../Applications/Application\ Loader.app/Contents/MacOS/itms/bin/iTMSTransporter'
+      itms_path = self.xcode_path + '../Applications/Application\ Loader.app/Contents/MacOS/itms/bin/iTMSTransporter'
+      if File.file?(itms_path)
+         return itms_path
+      else
+         return self.xcode_path + '../Applications/Application\ Loader.app/Contents/itms/bin/iTMSTransporter'
+      end
     end
 
     def self.fastlane_enabled?


### PR DESCRIPTION
Looks like the location of iTMSTransporter is slightly different in the current betas of Xcode 6.3 - fall back to the new beta location if there isn't a copy where we expect it to be from 6.2 and before.

This still causes deliver to silently fail if iTMSTransporter is in neither location - maybe it should throw an error if it's nowhere to be found?
