### PR TITLE
Use more recent version of commander

### DIFF
--- a/fastlane_core.gemspec
+++ b/fastlane_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json' # Because sometimes it's just not installed
   spec.add_dependency 'highline', '>= 1.7.2' # user inputs (e.g. passwords)
   spec.add_dependency 'colored' # coloured terminal output
-  spec.add_dependency 'commander', '>= 4.1.0' # CLI parser
+  spec.add_dependency 'commander', '>= 4.3.1' # CLI parser
   spec.add_dependency 'babosa' # transliterate strings
   spec.add_dependency 'excon', '~> 0.45.0' # Great HTTP Client
 


### PR DESCRIPTION
The older ones are incompatible because of their `'highline', '~> 1.6.11'` requirement.
