### PR TITLE
Direct log output to $stdout

### DIFF
--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -8,7 +8,7 @@ module FastlaneCore
       if is_test?
         @@log ||= Logger.new(nil) # don't show any logs when running tests
       else
-        @@log ||= Logger.new(STDOUT)
+        @@log ||= Logger.new($stdout)
       end
 
       @@log.formatter = proc do |severity, datetime, progname, msg|


### PR DESCRIPTION
Direct log output to `$stdout`, not `STDOUT`. `$stdout` is a redefinable global variable, while STDOUT is a constant and is always the actual standard output. `$stdout` defaults to `STDOUT`, so there would be no effect to making this change unless the end user has redefined `$stdout` (in which case they would desire this functionality). 
