### PR TITLE
Prevent failing if source and destination are identical when copying …

### DIFF
--- a/lib/fastlane_core/provisioning_profile.rb
+++ b/lib/fastlane_core/provisioning_profile.rb
@@ -40,6 +40,7 @@ module FastlaneCore
       end
 
       # Installs a provisioning profile for Xcode to use
+      # @return true
       def install(path)
         Helper.log.info "Installing provisioning profile..."
         profile_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
@@ -51,14 +52,14 @@ module FastlaneCore
           FileUtils.mkdir_p(profile_path)
         end
 
-        # copy to Xcode provisioning profile directory
-        FileUtils.copy(path, destination)
-
-        if File.exists?(destination)
-          return true
-        else
-          raise "Failed installation of provisioning profile at location: #{destination}".red
+        if path != destination
+          # copy to Xcode provisioning profile directory
+          FileUtils.copy(path, destination)
+          unless File.exist?(destination)
+            raise "Failed installation of provisioning profile at location: #{destination}".red
+          end
         end
+        true
       end
     end
   end


### PR DESCRIPTION
Fix for https://github.com/fastlane/gym/issues/2

This is one way of making it work. Another way would be to let gym check if the PP is already installed...

I wondered if I should add some debug log a well in the case the pp was installed, or return a different value (e.g. false if already exists, but that doesn't cover the case of the PP being copied from a source !? from destination but being also present under destination = e.g. if you install a second time), so I left true as return value in both cases.
