### PR TITLE
Should we prevent -t reuse?

### DIFF
--- a/lib/fastlane_core/configuration/commander_generator.rb
+++ b/lib/fastlane_core/configuration/commander_generator.rb
@@ -12,10 +12,12 @@ module FastlaneCore
         type = (option.is_string ? String : nil)
         short_option = option.short_option || "-#{option.key.to_s[0]}"
 
+        # https://github.com/commander-rb/commander/blob/master/lib/commander/runner.rb
         raise "Short option #{short_option} already taken for key #{option.key}".red if short_codes.include?short_option
         raise "-v is already used for the version (key #{option.key})".red if short_option == "-v"
         raise "-h is already used for the help screen (key #{option.key})".red if short_option == "-h"
-        
+        raise "-t is already used for the trace mode (key #{option.key})".red if short_option == "-t"
+
         short_codes << short_option
 
         # Example Call


### PR DESCRIPTION
Not sure about this at all, it's some notes I had laying around after noticing that there's some check to ensure short options aren't reused, yet there's also a -t in runner that is (at least sometimes) available.
