### PR TITLE
Fix for gym update available message showing wrong URL

### DIFF
--- a/lib/fastlane_core/update_checker.rb
+++ b/lib/fastlane_core/update_checker.rb
@@ -50,7 +50,10 @@ module FastlaneCore
       puts "# #{gem_name} #{available} is available. You are on #{current_version}.".green
       puts "# It is recommended to use the latest version.".green
       puts "# Update using 'sudo gem update #{gem_name.downcase}'.".green
-      puts "# To see what's new, open https://github.com/KrauseFx/#{gem_name}/releases.".green
+      if gem_name == "gym"
+        puts "# To see what's new, open https://github.com/KrauseFx/#{gem_name}/releases.".green
+      else
+        puts "# To see what's new, open https://github.com/KrauseFx/fastlane/#{gem_name}/releases.".green
       puts '#######################################################################'.green
     end
 


### PR DESCRIPTION
When showing an update message for gym the wrong url was provided for information on the new releases. This checks to see if the gem is gym and if so adds fastlane into the URL for new releases.
