### PR TITLE
PrintTable: recurse over hashes

### DIFF
--- a/lib/fastlane_core/configuration/configuration.rb
+++ b/lib/fastlane_core/configuration/configuration.rb
@@ -143,6 +143,9 @@ module FastlaneCore
       return value unless value.nil? # we already have a value
       return value if option.optional # as this value is not required, just return what we have
 
+      return value unless ask
+
+      # fallback to asking
       if Helper.is_test? or Helper.is_ci?
         # Since we don't want to be asked on tests, we'll just call the verify block with no value
         # to raise the exception that is shown when the user passes an invalid value
@@ -151,7 +154,7 @@ module FastlaneCore
         raise "No value found for '#{key}'"
       end
 
-      while ask && value.nil?
+      while value.nil?
         Helper.log.info "To not be asked about this value, you can specify it using '#{option.key}'".yellow
         value = ask("#{option.description}: ")
         # Also store this value to use it from now on
@@ -182,10 +185,11 @@ module FastlaneCore
       true
     end
 
-    def values
+    # see fetch
+    def values(ask: true)
       # As the user accesses all values, we need to iterate through them to receive all the values
       @available_options.each do |option|
-        @values[option.key] = fetch(option.key) unless @values[option.key]
+        @values[option.key] = fetch(option.key, ask: ask) unless @values[option.key]
       end
       @values
     end

--- a/lib/fastlane_core/print_table.rb
+++ b/lib/fastlane_core/print_table.rb
@@ -10,15 +10,24 @@ module FastlaneCore
         rows = self.collect_rows(options: options, hide_keys: hide_keys.map(&:to_s), prefix: '')
 
         params = {}
-        params[:rows] = rows
+        params[:rows] = limit_row_size rows
         params[:title] = title.green if title
         # params[:style] = {width: 80} # broken with 1.4.5
+        # workaround in the meantime
 
         puts ""
         puts Terminal::Table.new(params)
         puts ""
 
         params
+      end
+
+      def limit_row_size(rows, max_length = 100)
+        require 'fastlane_core/string_filters'
+
+        max_key_length = rows.map { |e| e[0].length }.max || 0
+        max_allowed_value_length = max_length - max_key_length - 7
+        rows.map { |e| [e[0], e[1].truncate(max_allowed_value_length)] }
       end
 
       def collect_rows(options: nil, hide_keys: [], prefix: '')

--- a/lib/fastlane_core/print_table.rb
+++ b/lib/fastlane_core/print_table.rb
@@ -28,7 +28,7 @@ module FastlaneCore
         max_allowed_value_length = max_length - max_key_length - 7
         rows.map do |e|
           value = e[1]
-          value = value.truncate(max_allowed_value_length) if value.is_a? String
+          value = value.truncate(max_allowed_value_length) if value.kind_of? String
           [e[0], value]
         end
       end

--- a/lib/fastlane_core/print_table.rb
+++ b/lib/fastlane_core/print_table.rb
@@ -10,16 +10,14 @@ module FastlaneCore
         rows = self.collect_rows(options: options, hide_keys: hide_keys.map(&:to_s), prefix: '')
 
         params = {}
-        params[:rows] = limit_row_size rows
+        params[:rows] = limit_row_size(rows)
         params[:title] = title.green if title
-        # params[:style] = {width: 80} # broken with 1.4.5
-        # workaround in the meantime
 
         puts ""
         puts Terminal::Table.new(params)
         puts ""
 
-        params
+        return params
       end
 
       def limit_row_size(rows, max_length = 100)

--- a/lib/fastlane_core/print_table.rb
+++ b/lib/fastlane_core/print_table.rb
@@ -2,7 +2,7 @@ module FastlaneCore
   class PrintTable
     class << self
       # This method prints out all the user inputs in a nice table. Useful to summarize the run
-      # You can pass an array to `hide_key` if you don't want certain elements to show up (symbols)
+      # You can pass an array to `hide_keys` if you don't want certain elements to show up (symbols or strings)
       def print_values(config: nil, title: nil, hide_keys: [])
         require 'terminal-table'
 

--- a/lib/fastlane_core/print_table.rb
+++ b/lib/fastlane_core/print_table.rb
@@ -3,11 +3,12 @@ module FastlaneCore
     class << self
       # This method prints out all the user inputs in a nice table. Useful to summarize the run
       # You can pass an array to `hide_keys` if you don't want certain elements to show up (symbols or strings)
-      def print_values(config: nil, title: nil, hide_keys: [])
+      # You can pass an array to `mask_keys` if you want to mask certain elements (symbols or strings)
+      def print_values(config: nil, title: nil, hide_keys: [], mask_keys: [])
         require 'terminal-table'
 
         options = config.nil? ? {} : config.values
-        rows = self.collect_rows(options: options, hide_keys: hide_keys.map(&:to_s), prefix: '')
+        rows = self.collect_rows(options: options, hide_keys: hide_keys.map(&:to_s), mask_keys: mask_keys.map(&:to_s), prefix: '')
 
         params = {}
         params[:rows] = limit_row_size(rows)
@@ -25,10 +26,14 @@ module FastlaneCore
 
         max_key_length = rows.map { |e| e[0].length }.max || 0
         max_allowed_value_length = max_length - max_key_length - 7
-        rows.map { |e| [e[0], e[1].truncate(max_allowed_value_length)] }
+        rows.map do |e|
+          value = e[1]
+          value = value.truncate(max_allowed_value_length) if value.is_a? String
+          [e[0], value]
+        end
       end
 
-      def collect_rows(options: nil, hide_keys: [], prefix: '')
+      def collect_rows(options: nil, hide_keys: [], mask_keys: [], prefix: '', mask: '********')
         rows = []
 
         options.each do |key, value|
@@ -36,9 +41,10 @@ module FastlaneCore
           next if value.nil?
           next if value.to_s == ""
           next if hide_keys.include?(prefixed_key)
+          value = mask if mask_keys.include?(prefixed_key)
 
           if value.respond_to? :key
-            rows.concat self.collect_rows(options: value, hide_keys: hide_keys, prefix: "#{prefix}#{key}.")
+            rows.concat self.collect_rows(options: value, hide_keys: hide_keys, mask_keys: mask_keys, prefix: "#{prefix}#{key}.", mask: mask)
           else
             rows << [prefixed_key, value]
           end

--- a/lib/fastlane_core/print_table.rb
+++ b/lib/fastlane_core/print_table.rb
@@ -7,7 +7,7 @@ module FastlaneCore
       def print_values(config: nil, title: nil, hide_keys: [], mask_keys: [])
         require 'terminal-table'
 
-        options = config.nil? ? {} : config.values
+        options = config.nil? ? {} : config.values(ask: false)
         rows = self.collect_rows(options: options, hide_keys: hide_keys.map(&:to_s), mask_keys: mask_keys.map(&:to_s), prefix: '')
 
         params = {}

--- a/lib/fastlane_core/string_filters.rb
+++ b/lib/fastlane_core/string_filters.rb
@@ -1,0 +1,34 @@
+class String
+  # Truncates a given +text+ after a given <tt>length</tt> if +text+ is longer than <tt>length</tt>:
+  #
+  #   'Once upon a time in a world far far away'.truncate(27)
+  #   # => "Once upon a time in a wo..."
+  #
+  # Pass a string or regexp <tt>:separator</tt> to truncate +text+ at a natural break:
+  #
+  #   'Once upon a time in a world far far away'.truncate(27, separator: ' ')
+  #   # => "Once upon a time in a..."
+  #
+  #   'Once upon a time in a world far far away'.truncate(27, separator: /\s/)
+  #   # => "Once upon a time in a..."
+  #
+  # The last characters will be replaced with the <tt>:omission</tt> string (defaults to "...")
+  # for a total length not exceeding <tt>length</tt>:
+  #
+  #   'And they found that many people were sleeping better.'.truncate(25, omission: '... (continued)')
+  #   # => "And they f... (continued)"
+  def truncate(truncate_at, options = {})
+    return dup unless length > truncate_at
+
+    omission = options[:omission] || '...'
+    length_with_room_for_omission = truncate_at - omission.length
+    stop = \
+      if options[:separator]
+        rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission
+      else
+        length_with_room_for_omission
+      end
+
+    "#{self[0, stop]}#{omission}"
+  end
+end

--- a/spec/print_table_spec.rb
+++ b/spec/print_table_spec.rb
@@ -64,8 +64,6 @@ describe FastlaneCore do
       expect(value[:rows]).to eq([['output', '..']])
     end
 
-    # This isn't implemented as using style in 1.4.5 breaks terminal
-    # see https://github.com/tj/terminal-table/issues/23
     it "breaks down long lines" do
       long_breakable_text = 'bar ' * 40
       @config[:cert_name] = long_breakable_text
@@ -73,7 +71,6 @@ describe FastlaneCore do
       expect(value[:rows].count).to eq(1)
       expect(value[:rows][0][1]).to end_with '...'
       expect(value[:rows][0][1].length).to be < long_breakable_text.length
-      # expect(value[:style]).to eq({width: 80})
     end
   end
 end

--- a/spec/print_table_spec.rb
+++ b/spec/print_table_spec.rb
@@ -70,7 +70,9 @@ describe FastlaneCore do
       long_breakable_text = 'bar ' * 40
       @config[:cert_name] = long_breakable_text
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output])
-      expect(value[:rows]).to eq([['cert_name', long_breakable_text]])
+      expect(value[:rows].count).to eq(1)
+      expect(value[:rows][0][1]).to end_with '...'
+      expect(value[:rows][0][1].length).to be < long_breakable_text.length
       # expect(value[:style]).to eq({width: 80})
     end
   end

--- a/spec/print_table_spec.rb
+++ b/spec/print_table_spec.rb
@@ -13,13 +13,23 @@ describe FastlaneCore do
                            default_value: ".",
                             verify_block: proc do |value|
                               raise "Could not find output directory '#{value}'".red unless File.exist?(value)
-                            end)
+                            end),
+        FastlaneCore::ConfigItem.new(key: :a_hash,
+                                     description: "Metadata: A hash",
+                                     optional: true,
+                                     is_string: false)
       ]
       @values = {
         cert_name: "asdf",
-        output: ".."
+        output: "..",
+        a_hash: {}
       }
       @config = FastlaneCore::Configuration.create(@options, @values)
+    end
+
+    it "supports nil config" do
+      value = FastlaneCore::PrintTable.print_values
+      expect(value).to eq({ rows: [] })
     end
 
     it "prints out all the information in a nice table" do
@@ -27,12 +37,41 @@ describe FastlaneCore do
 
       value = FastlaneCore::PrintTable.print_values(config: @config, title: title)
       expect(value[:title]).to eq(title.green)
-      expect(value[:rows]).to eq([[:cert_name, "asdf"], [:output, '..']])
+      expect(value[:rows]).to eq([['cert_name', "asdf"], ['output', '..']])
     end
 
-    it "supports hide_keys property" do
+    it "supports hide_keys property with symbols" do
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name])
-      expect(value).to eq({ rows: [[:output, '..']] })
+      expect(value[:rows]).to eq([['output', '..']])
+    end
+
+    it "supports hide_keys property with strings" do
+      value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: ['cert_name'])
+      expect(value[:rows]).to eq([['output', '..']])
+    end
+
+    it "recurses over hashes" do
+      @config[:a_hash][:foo] = 'bar'
+      @config[:a_hash][:bar] = { foo: 'bar' }
+      value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name])
+      expect(value[:rows]).to eq([['output', '..'], ['a_hash.foo', 'bar'], ['a_hash.bar.foo', 'bar']])
+    end
+
+    it "supports hide_keys property in hashes" do
+      @config[:a_hash][:foo] = 'bar'
+      @config[:a_hash][:bar] = { foo: 'bar' }
+      value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, 'a_hash.foo', 'a_hash.bar.foo'])
+      expect(value[:rows]).to eq([['output', '..']])
+    end
+
+    # This isn't implemented as using style in 1.4.5 breaks terminal
+    # see https://github.com/tj/terminal-table/issues/23
+    it "breaks down long lines" do
+      long_breakable_text = 'bar ' * 40
+      @config[:cert_name] = long_breakable_text
+      value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output])
+      expect(value[:rows]).to eq([['cert_name', long_breakable_text]])
+      # expect(value[:style]).to eq({width: 80})
     end
   end
 end

--- a/spec/print_table_spec.rb
+++ b/spec/print_table_spec.rb
@@ -5,7 +5,6 @@ describe FastlaneCore do
         FastlaneCore::ConfigItem.new(key: :cert_name,
                                 env_name: "SIGH_PROVISIONING_PROFILE_NAME",
                              description: "Set the profile name",
-                           default_value: "production_default",
                             verify_block: nil),
         FastlaneCore::ConfigItem.new(key: :output,
                                 env_name: "SIGH_OUTPUT_PATH",
@@ -68,6 +67,13 @@ describe FastlaneCore do
       @config[:a_hash][:bar] = { foo: 'bar' }
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, :a_bool, 'a_hash.foo', 'a_hash.bar.foo'])
       expect(value[:rows]).to eq([['output', '..']])
+    end
+
+    it "supports printing default values and ignores missing unset ones " do
+      @config[:cert_name] = nil # compulsory without default
+      @config[:output] = nil    # compulsory with default
+      value = FastlaneCore::PrintTable.print_values(config: @config)
+      expect(value[:rows]).to eq([['output', '.'], ['a_bool', true]])
     end
 
     it "breaks down long lines" do


### PR DESCRIPTION
This implements 3 things:
- allow to recurse over hashes
- allow to mask some some entries (instead of hiding them)
- do not simulate asking for the entry when in test of ci mode if one is in ask: false mode.

If for example mask_keys is rejected, the rest should be recovered :)
