### PR TITLE
Avoid returning watchOS and tvOS simulators

### DIFF
--- a/lib/fastlane_core/simulator.rb
+++ b/lib/fastlane_core/simulator.rb
@@ -10,7 +10,17 @@ module FastlaneCore
         @devices = []
         os_type = 'unknown'
         os_version = 'unknown'
-        `xcrun simctl list devices`.split(/\n/).each do |line|
+        output = ''
+        Open3.popen3('xcrun simctl list devices') do |stdin, stdout, stderr, wait_thr|
+          output = stdout.read
+        end
+
+        unless output.include?("== Devices ==")
+          Helper.log.error "xcrun simctl CLI broken, run `xcrun simctl list devices` and make sure it works".red
+          raise "xcrun simctl not working.".red
+        end
+
+        output.split(/\n/).each do |line|
           next if line.match(/^== /)
           if line.match(/^-- /)
             (os_type, os_version) = line.gsub(/-- (.*) --/, '\1').split

--- a/lib/fastlane_core/simulator.rb
+++ b/lib/fastlane_core/simulator.rb
@@ -6,23 +6,24 @@ module FastlaneCore
       def all
         return @devices if @devices
         Helper.log.info "Fetching available devices" if $verbose
-        
+
         @devices = []
-        (os_type, os_version) = ['unknown', 'unknown']
+        os_type = 'unknown'
+        os_version = 'unknown'
         `xcrun simctl list devices`.split(/\n/).each do |line|
-          next if line.match /^== /
-          if line.match /^-- /
+          next if line.match(/^== /)
+          if line.match(/^-- /)
             (os_type, os_version) = line.gsub(/-- (.*) --/, '\1').split
           else
             # iPad 2 (0EDE6AFC-3767-425A-9658-AAA30A60F212) (Shutdown)
             # iPad Air 2 (4F3B8059-03FD-4D72-99C0-6E9BBEE2A9CE) (Shutdown) (unavailable, device type profile not found)
-            match = line.match /\s+([^\(]+) \(([-0-9A-F]+)\) \((?:[^\(]+)\)(.*unavailable.*)?/
+            match = line.match(/\s+([^\(]+) \(([-0-9A-F]+)\) \((?:[^\(]+)\)(.*unavailable.*)?/)
             if match && !match[3] && os_type == 'iOS'
               @devices << Device.new(name: match[1], ios_version: os_version, udid: match[2])
             end
           end
         end
-        
+
         return @devices
       end
 

--- a/lib/fastlane_core/simulator.rb
+++ b/lib/fastlane_core/simulator.rb
@@ -4,7 +4,6 @@ module FastlaneCore
   class Simulator
     class << self
       def all
-        return @devices if @devices
         Helper.log.info "Fetching available devices" if $verbose
 
         @devices = []

--- a/lib/fastlane_core/simulator.rb
+++ b/lib/fastlane_core/simulator.rb
@@ -6,32 +6,23 @@ module FastlaneCore
       def all
         return @devices if @devices
         Helper.log.info "Fetching available devices" if $verbose
-
-        # we do it using open since ` just randomly hangs with instruments -s
-        output = ''
-        Open3.popen3('instruments -s') do |stdin, stdout, stderr, wait_thr|
-          output = stdout.read
-        end
-
-        unless output.include?("Known Devices")
-          Helper.log.error "Instruments CLI broken, run `instruments -s` and make sure it works".red
-          Helper.log.error "The easiest way to fix this is to restart your Mac".red
-          raise "Instruments CLI not working.".red
-        end
-
-        output = output.split("Known Devices:").last.split("Known Templates:").first
+        
         @devices = []
-        output.split("\n").each do |current|
-          m = current.match(/(.*) \((.*)\) \[(.*)\]/)
-          next unless m
-          name = m[1].to_s.strip
-          ios = m[2].to_s.strip
-          udid = m[3].to_s.strip
-          next unless udid.include?("-") # as we want to ignore the real devices
-
-          @devices << Device.new(name: name, ios_version: ios, udid: udid)
+        (os_type, os_version) = ['unknown', 'unknown']
+        `xcrun simctl list devices`.split(/\n/).each do |line|
+          next if line.match /^== /
+          if line.match /^-- /
+            (os_type, os_version) = line.gsub(/-- (.*) --/, '\1').split
+          else
+            # iPad 2 (0EDE6AFC-3767-425A-9658-AAA30A60F212) (Shutdown)
+            # iPad Air 2 (4F3B8059-03FD-4D72-99C0-6E9BBEE2A9CE) (Shutdown) (unavailable, device type profile not found)
+            match = line.match /\s+([^\(]+) \(([-0-9A-F]+)\) \((?:[^\(]+)\)(.*unavailable.*)?/
+            if match && !match[3] && os_type == 'iOS'
+              @devices << Device.new(name: match[1], ios_version: os_version, udid: match[2])
+            end
+          end
         end
-
+        
         return @devices
       end
 
@@ -39,27 +30,6 @@ module FastlaneCore
         @devices = nil
       end
     end
-
-    # Example Output for `instruments -s`
-    #
-    #   Known Devices:
-    #   Felix [A8B765B9-70D4-5B89-AFF5-EDDAF0BC8AAA]
-    #   Felix Krause's iPhone 6 (9.0.1) [2cce6c8deb5ea9a46e19304f4c4e665069ccaaaa]
-    #   iPad 2 (9.0) [863234B6-C857-4DF3-9E27-897DEDF26EDA]
-    #   iPad Air (9.0) [3827540A-D953-49D3-BC52-B66FC59B085E]
-    #   iPad Air 2 (9.0) [6731E2F9-B70A-4102-9B49-6AEFE300F460]
-    #   iPad Retina (9.0) [DFEE2E76-DABF-47C6-AA1A-ACF873E57435]
-    #   iPhone 4s (9.0) [CDEB0462-9ECD-40C7-9916-B7C44EC10E17]
-    #   iPhone 5 (9.0) [1685B071-AFB2-4DC1-BE29-8370BA4A6EBD]
-    #   iPhone 5s (9.0) [C60F3E7A-3D0E-407B-8D0A-EDAF033ED626]
-    #   iPhone 6 (9.0) [4A822E0C-4873-4F12-B798-8B39613B24CE]
-    #   iPhone 6 Plus (9.0) [A522ACFF-7948-4344-8CA8-3F62ED9FFB18]
-    #   iPhone 6s (9.0) [C956F5AA-2EA3-4141-B7D2-C5BE6250A60D]
-    #   iPhone 6s Plus (9.0) [A3754407-21A3-4A80-9559-3170BB3D50FC]
-    #   Known Templates:
-    #   "/Applications/Xcode70.app/Contents/Applications/Instruments.app/Contents/PlugIns/AutomationInstrument.xrplugin/Contents/Resources/Automation.tracetemplate"
-    #   "/Applications/Xcode70.app/Contents/Applications/Instruments.app/Contents/PlugIns/OpenGLESAnalyzerInstrument.xrplugin/Contents/Resources/OpenGL ES Analysis.tracetemplate"
-    #   "/Applications/Xcode70.app/Contents/Applications/Instruments.app/Contents/PlugIns/XRMobileDeviceDiscoveryPlugIn.xrplugin/Contents/Resources/Energy Diagnostics.tracetemplate"
 
     # Use the UDID for the given device when setting the destination
     # Why? Because we might get this error message

--- a/spec/simulator_spec.rb
+++ b/spec/simulator_spec.rb
@@ -40,12 +40,23 @@ describe FastlaneCore do
 
       devices = FastlaneCore::Simulator.all
       expect(devices.count).to eq(4)
+      puts "devices: #{devices}"
 
-      expect(devices).to contain_exactly(
-        Device.new(name: "iPhone 4s", ios_version: "8.1", udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13"),
-        Device.new(name: "iPhone 5", ios_version: "8.1", udid: "0D80C781-8702-4156-855E-A9B737FF92D3"),
-        Device.new(name: "iPhone 6s Plus", ios_version: "9.1", udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0"),
-        Device.new(name: "iPad Air 2", ios_version: "9.1", udid: "961A7DF9-F442-4CA5-B28E-D96288D39DCA")
+      expect(devices[0]).to have_attributes(
+        :name => "iPhone 4s", :ios_version => "8.1", 
+        :udid => "DBABD2A2-0144-44B0-8F93-263EB656FC13"
+      )
+      expect(devices[1]).to have_attributes(
+        :name => "iPhone 5", :ios_version => "8.1",
+        :udid => "0D80C781-8702-4156-855E-A9B737FF92D3"
+      )
+      expect(devices[2]).to have_attributes(
+        :name => "iPhone 6s Plus", :ios_version => "9.1",
+        :udid => "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0"
+      )
+      expect(devices[3]).to have_attributes(
+        :name => "iPad Air 2", :ios_version => "9.1",
+        :udid => "961A7DF9-F442-4CA5-B28E-D96288D39DCA"
       )
     end
 

--- a/spec/simulator_spec.rb
+++ b/spec/simulator_spec.rb
@@ -3,56 +3,59 @@ require 'open3'
 describe FastlaneCore do
   describe FastlaneCore::Simulator do
     before do
-      @valid_simulators = "Known Devices:
-          Felix [A8B765B9-70D4-5B89-AFF5-EDDAF0BC8AAA]
-          Felix Krause's iPhone 6 (9.0.1) [2cce6c8deb5ea9a46e19304f4c4e665069ccaaaa]
-          iPad 2 (9.0) [863234B6-C857-4DF3-9E27-897DEDF26EDA]
-          iPad Air (9.0) [3827540A-D953-49D3-BC52-B66FC59B085E]
-          iPad Air 2 (9.0) [6731E2F9-B70A-4102-9B49-6AEFE300F460]
-          iPad Retina (9.0) [DFEE2E76-DABF-47C6-AA1A-ACF873E57435]
-          iPhone 4s (9.0) [CDEB0462-9ECD-40C7-9916-B7C44EC10E17]
-          iPhone 5 (9.0) [1685B071-AFB2-4DC1-BE29-8370BA4A6EBD]
-          iPhone 5s (9.0) [C60F3E7A-3D0E-407B-8D0A-EDAF033ED626]
-          iPhone 6 (9.0) [4A822E0C-4873-4F12-B798-8B39613B24CE]
-          iPhone 6 Plus (9.0) [A522ACFF-7948-4344-8CA8-3F62ED9FFB18]
-          iPhone 6s (9.0) [C956F5AA-2EA3-4141-B7D2-C5BE6250A60D]
-          iPhone 6s Plus (9.0) [A3754407-21A3-4A80-9559-3170BB3D50FC]
-          Known Templates:
-          ..."
+      @valid_simulators = "== Devices ==
+-- iOS 7.1 --
+    iPhone 4s (8E3D97C4-1143-4E84-8D57-F697140F2ED0) (Shutdown) (unavailable, failed to open liblaunch_sim.dylib)
+    iPhone 5 (65D0F571-1260-4241-9583-611EAF4D56AE) (Shutdown) (unavailable, failed to open liblaunch_sim.dylib)
+-- iOS 8.1 --
+    iPhone 4s (DBABD2A2-0144-44B0-8F93-263EB656FC13) (Shutdown)
+    iPhone 5 (0D80C781-8702-4156-855E-A9B737FF92D3) (Shutdown)
+-- iOS 9.1 --
+    iPhone 6s Plus (BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0) (Shutdown)
+    Resizable iPad (B323CCB4-840B-4B26-B57B-71681D6C30C2) (Shutdown) (unavailable, device type profile not found)
+    iPad Air 2 (961A7DF9-F442-4CA5-B28E-D96288D39DCA) (Shutdown)
+-- tvOS 9.0 --
+    Apple TV 1080p (D239A51B-A61C-4B60-B4D6-B7EC16595128) (Shutdown)
+-- watchOS 2.0 --
+    Apple Watch - 38mm (FE0C82A5-CDD2-4062-A62C-21278EEE32BB) (Shutdown)
+    Apple Watch - 38mm (66D1BF17-3003-465F-A165-E6E3A565E5EB) (Shutdown)
+"
       FastlaneCore::Simulator.clear_cache
     end
 
-    it "raises an error if instruments CLI prints garbage" do
+    it "raises an error if xcrun CLI prints garbage" do
       response = "response"
       expect(response).to receive(:read).and_return("💩")
-      expect(Open3).to receive(:popen3).with("instruments -s").and_yield(nil, response, nil, nil)
+      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
       expect do
         devices = FastlaneCore::Simulator.all
-      end.to raise_error("Instruments CLI not working.".red)
+      end.to raise_error("xcrun simctl not working.".red)
     end
 
-    it "properly parses the instruments output and generates Device objects" do
+    it "properly parses the simctl output and generates Device objects" do
       response = "response"
       expect(response).to receive(:read).and_return(@valid_simulators)
-      expect(Open3).to receive(:popen3).with("instruments -s").and_yield(nil, response, nil, nil)
+      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
       devices = FastlaneCore::Simulator.all
-      expect(devices.count).to eq(11)
+      expect(devices.count).to eq(4)
 
-      sim = devices.first
-      expect(sim.name).to eq('iPad 2')
-      expect(sim.udid).to eq('863234B6-C857-4DF3-9E27-897DEDF26EDA')
-      expect(sim.ios_version).to eq('9.0')
+      expect(devices).to contain_exactly(
+        Device.new(name: "iPhone 4s", ios_version: "8.1", udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13"),
+        Device.new(name: "iPhone 5", ios_version: "8.1", udid: "0D80C781-8702-4156-855E-A9B737FF92D3"),
+        Device.new(name: "iPhone 6s Plus", ios_version: "9.1", udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0"),
+        Device.new(name: "iPad Air 2", ios_version: "9.1", udid: "961A7DF9-F442-4CA5-B28E-D96288D39DCA"),
+      )
     end
 
     it "doesn't call the CLI twice as it's super slow" do
       response = "response"
       expect(response).to receive(:read).and_return(@valid_simulators)
-      expect(Open3).to receive(:popen3).with("instruments -s").and_yield(nil, response, nil, nil)
+      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
-      expect(FastlaneCore::Simulator.all.count).to eq(11)
-      expect(FastlaneCore::Simulator.all.count).to eq(11)
+      expect(FastlaneCore::Simulator.all.count).to eq(4)
+      expect(FastlaneCore::Simulator.all.count).to eq(4)
     end
   end
 end

--- a/spec/simulator_spec.rb
+++ b/spec/simulator_spec.rb
@@ -45,7 +45,7 @@ describe FastlaneCore do
         Device.new(name: "iPhone 4s", ios_version: "8.1", udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13"),
         Device.new(name: "iPhone 5", ios_version: "8.1", udid: "0D80C781-8702-4156-855E-A9B737FF92D3"),
         Device.new(name: "iPhone 6s Plus", ios_version: "9.1", udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0"),
-        Device.new(name: "iPad Air 2", ios_version: "9.1", udid: "961A7DF9-F442-4CA5-B28E-D96288D39DCA"),
+        Device.new(name: "iPad Air 2", ios_version: "9.1", udid: "961A7DF9-F442-4CA5-B28E-D96288D39DCA")
       )
     end
 

--- a/spec/simulator_spec.rb
+++ b/spec/simulator_spec.rb
@@ -43,7 +43,7 @@ describe FastlaneCore do
       puts "devices: #{devices}"
 
       expect(devices[0]).to have_attributes(
-        name: "iPhone 4s", ios_version: "8.1", 
+        name: "iPhone 4s", ios_version: "8.1",
         udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13"
       )
       expect(devices[1]).to have_attributes(

--- a/spec/simulator_spec.rb
+++ b/spec/simulator_spec.rb
@@ -59,6 +59,5 @@ describe FastlaneCore do
         udid: "961A7DF9-F442-4CA5-B28E-D96288D39DCA"
       )
     end
-
   end
 end

--- a/spec/simulator_spec.rb
+++ b/spec/simulator_spec.rb
@@ -60,13 +60,5 @@ describe FastlaneCore do
       )
     end
 
-    it "doesn't call the CLI twice as it's super slow" do
-      response = "response"
-      expect(response).to receive(:read).and_return(@valid_simulators)
-      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
-
-      expect(FastlaneCore::Simulator.all.count).to eq(4)
-      expect(FastlaneCore::Simulator.all.count).to eq(4)
-    end
   end
 end

--- a/spec/simulator_spec.rb
+++ b/spec/simulator_spec.rb
@@ -43,20 +43,20 @@ describe FastlaneCore do
       puts "devices: #{devices}"
 
       expect(devices[0]).to have_attributes(
-        :name => "iPhone 4s", :ios_version => "8.1", 
-        :udid => "DBABD2A2-0144-44B0-8F93-263EB656FC13"
+        name: "iPhone 4s", ios_version: "8.1", 
+        udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13"
       )
       expect(devices[1]).to have_attributes(
-        :name => "iPhone 5", :ios_version => "8.1",
-        :udid => "0D80C781-8702-4156-855E-A9B737FF92D3"
+        name: "iPhone 5", ios_version: "8.1",
+        udid: "0D80C781-8702-4156-855E-A9B737FF92D3"
       )
       expect(devices[2]).to have_attributes(
-        :name => "iPhone 6s Plus", :ios_version => "9.1",
-        :udid => "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0"
+        name: "iPhone 6s Plus", ios_version: "9.1",
+        udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0"
       )
       expect(devices[3]).to have_attributes(
-        :name => "iPad Air 2", :ios_version => "9.1",
-        :udid => "961A7DF9-F442-4CA5-B28E-D96288D39DCA"
+        name: "iPad Air 2", ios_version: "9.1",
+        udid: "961A7DF9-F442-4CA5-B28E-D96288D39DCA"
       )
     end
 


### PR DESCRIPTION
instruments now returns watchOS and tvOS, for example:

iPhone 6 (9.0) + Apple Watch - 38mm (2.0) [66D1BF17-3003-465F-A165-E6E3A565E5EB]
Apple TV 1080p (9.0) [D239A51B-A61C-4B60-B4D6-B7EC16595128]

xcrun simctl list devices returns simulators for all Xcodes on the machine, so when listing available simulators we need to exclude those marked unavailable to the current Xcode

Although Xcode 7 includes JSON output from simctl list, I have used the older line style as this remains compatible with Xcode 6.4 (for those who still need to test against iOS 7 like me).
