### PR TITLE
Disable Logger output buffering

### DIFF
--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -4,6 +4,8 @@ module FastlaneCore
   module Helper
     # Logging happens using this method
     def self.log
+      $stdout.sync = true
+
       if is_test?
         @@log ||= Logger.new(nil) # don't show any logs when running tests
       else


### PR DESCRIPTION
Because by default buffering to stdout is enabled, in Jenkins the fastlane output appears only after the buffer is flushed by the system, this creates false impression than nothing happens (e.g. no realtime output).

This fixes this issue.
