### PR TITLE
[Language] Update cmn-* to zh-*.

### DIFF
--- a/lib/fastlane_core/languages.rb
+++ b/lib/fastlane_core/languages.rb
@@ -6,7 +6,6 @@ module FastlaneCore
     ALL_LANGUAGES_LEGACY = ["da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi-FI", "fr-CA", "fr-FR", "id-ID", "it-IT", "ja-JP", "ko-KR", "ms-MY", "nl-NL", "no-NO", "pt-BR", "pt-PT", "ru-RU", "sv-SE", "th-TH", "tr-TR", "vi-VI", "cmn-Hans", "cmn-Hant"]
 
     # The new format used from September 2015 on
-    # Open Radar 22548000 to change from cmn-Hant to zh-Hans
-    ALL_LANGUAGES = ["da", "de-DE", "el", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "id", "it", "ja", "ko", "ms", "nl-NL", "no", "pt-BR", "pt-PT", "ru", "sv", "th", "tr", "vi", "cmn-Hans", "cmn-Hant"]
+    ALL_LANGUAGES = ["da", "de-DE", "el", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "id", "it", "ja", "ko", "ms", "nl-NL", "no", "pt-BR", "pt-PT", "ru", "sv", "th", "tr", "vi", "zh-Hans", "zh-Hant"]
   end
 end


### PR DESCRIPTION
I had to change `can-Hans` to `zh-Hans` to be able to deliver the Artsy app: https://github.com/artsy/eigen/tree/eloy-start-fastlane-integration/fastlane/metadata/zh-Hans

I _assume_ this means that the radar that’s mentioned in the code has been fixed. (Alas it’s not on OpenRadar and so I can’t check for myself, if it’s yours then please check it.) Also note that I have only tested this with the `Hans` variant, it’s simply my assumption that this means that `Hant` is also updated.

Do you have a way of automatically verifying this?
