### PR TITLE
Match keys exactly in project.build_settings

### DIFF
--- a/lib/fastlane_core/project.rb
+++ b/lib/fastlane_core/project.rb
@@ -196,7 +196,7 @@ module FastlaneCore
       end
 
       begin
-        result = @build_settings.split("\n").find { |c| c.include? key }
+        result = @build_settings.split("\n").find { |c| c.split(" = ").first.strip == key }
         return result.split(" = ").last
       rescue => ex
         return nil if optional # an optional value, we really don't care if something goes wrong

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -74,5 +74,16 @@ describe FastlaneCore do
         expect(@project.schemes).to eq(["Mac"])
       end
     end
+
+    describe "Build Settings" do
+      before do
+        options = { project: "./spec/fixtures/projects/Example.xcodeproj" }
+        @project = FastlaneCore::Project.new(options)
+      end
+
+      it "IPHONEOS_DEPLOYMENT_TARGET should be 9.0" do
+        expect(@project.build_settings(key: "IPHONEOS_DEPLOYMENT_TARGET")).to eq("9.0")
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes an issues which occurs when the project.build_settings is called with a key that looks like an existing key or when the key that is passed in matches the build settings value. This can be seen when checking the iOS project for the `IPHONEOS_DEPLOYMENT_TARGET` because the build settings look something like:

```
DEPLOYMENT_TARGET_CLANG_ENV_NAME = IPHONEOS_DEPLOYMENT_TARGET
DEPLOYMENT_TARGET_SETTING_NAME = IPHONEOS_DEPLOYMENT_TARGET
IPHONEOS_DEPLOYMENT_TARGET = 9.0
```

This patch makes sure we match on the key exactly as it is passed in.
