### PR TITLE
Properly validate Arrays as options

### DIFF
--- a/lib/fastlane_core/configuration/commander_generator.rb
+++ b/lib/fastlane_core/configuration/commander_generator.rb
@@ -13,8 +13,8 @@ module FastlaneCore
       options.each do |option|
         next if option.description.to_s.length == 0 # "private" options
 
-        appendix = (option.is_string ? "STRING" : "")
-        type = (option.is_string ? String : nil)
+        appendix = (option.string? ? "STRING" : "")
+        type = (option.string? ? String : nil)
         short_option = option.short_option
 
         raise "Short option #{short_option} already taken for key #{option.key}".red if short_codes.include? short_option

--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -13,7 +13,7 @@ module FastlaneCore
     #   You have to raise a specific exception if something goes wrong. Append .red after the string
     # @param is_string (String) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
     # @param optional (Boolean) is false by default. If set to true, also string values will not be asked to the user
-    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, optional: false)
+    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, is_array: false, optional: false)
       raise "key must be a symbol" unless key.kind_of? Symbol
       raise "env_name must be a String" unless (env_name || '').kind_of? String
       if short_option
@@ -30,6 +30,7 @@ module FastlaneCore
       @default_value = default_value
       @verify_block = verify_block
       @is_string = is_string
+      @is_array = is_array
       @optional = optional
     end
 
@@ -46,6 +47,9 @@ module FastlaneCore
       if value
         if @is_string
           raise "'#{self.key}' value must be a String! Found #{value.class} instead.".red unless value.kind_of? String
+        elsif @is_array
+          # if we've been told that this option is an array, delimit elements by comma
+          value = value.split(',')
         end
 
         if @verify_block

--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -66,8 +66,10 @@ module FastlaneCore
 
     # Returns an updated value type (if necessary)
     def auto_convert_value(value)
-      case data_type
-      when Array
+      # We must cast the type to String before comparing because of the way that Ruby
+      # handles class comparisons
+      case data_type.to_s
+      when 'Array'
         value = value.split(',')
       else
         # Special treatment if the user specififed true, false or YES, NO

--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -47,7 +47,7 @@ module FastlaneCore
     def valid?(value)
       # we also allow nil values, which do not have to be verified.
       if value
-        if data_type == String
+        if string?
           raise "'#{self.key}' value must be a String! Found #{value.class} instead.".red unless value.kind_of? String
         end
 

--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -1,6 +1,6 @@
 module FastlaneCore
   class ConfigItem
-    attr_accessor :key, :env_name, :description, :short_option, :default_value, :verify_block, :is_string, :optional
+    attr_accessor :key, :env_name, :description, :short_option, :default_value, :verify_block, :optional
 
     # Creates a new option
     # @param key (Symbol) the key which is used as command paramters or key in the fastlane tools
@@ -11,11 +11,13 @@ module FastlaneCore
     # @param verify_block an optional block which is called when a new value is set.
     #   Check value is valid. This could be type checks or if a folder/file exists
     #   You have to raise a specific exception if something goes wrong. Append .red after the string
-    # @param is_string (String) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
+    # @param is_string (Boolean) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
+    # @param type (Class) the data type of this config item. Takes precedence over `is_string`
     # @param optional (Boolean) is false by default. If set to true, also string values will not be asked to the user
-    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, is_array: false, optional: false)
+    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: false)
       raise "key must be a symbol" unless key.kind_of? Symbol
       raise "env_name must be a String" unless (env_name || '').kind_of? String
+
       if short_option
         raise "short_option must be a String of length 1" unless short_option.kind_of? String and short_option.delete('-').length == 1
       end
@@ -30,7 +32,7 @@ module FastlaneCore
       @default_value = default_value
       @verify_block = verify_block
       @is_string = is_string
-      @is_array = is_array
+      @data_type = type
       @optional = optional
     end
 
@@ -45,11 +47,8 @@ module FastlaneCore
     def valid?(value)
       # we also allow nil values, which do not have to be verified.
       if value
-        if @is_string
+        if data_type == String
           raise "'#{self.key}' value must be a String! Found #{value.class} instead.".red unless value.kind_of? String
-        elsif @is_array
-          # if we've been told that this option is an array, delimit elements by comma
-          value = value.split(',')
         end
 
         if @verify_block
@@ -67,14 +66,29 @@ module FastlaneCore
 
     # Returns an updated value type (if necessary)
     def auto_convert_value(value)
-      # Special treatment if the user specififed true, false or YES, NO
-      if %w(YES yes true).include?(value)
-        value = true
-      elsif %w(NO no false).include?(value)
-        value = false
+      case data_type
+      when Array
+        value = value.split(',')
+      else
+        # Special treatment if the user specififed true, false or YES, NO
+        if %w(YES yes true).include?(value)
+          value = true
+        elsif %w(NO no false).include?(value)
+          value = false
+        end
       end
 
       return value
+    end
+
+    # Determines the defined data type of this ConfigItem
+    def data_type
+      @data_type ? @data_type : (@is_string ? String : nil)
+    end
+
+    # Replaces the attr_accessor, but maintains the same interface
+    def is_string
+      data_type == String
     end
 
     def to_s

--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -85,7 +85,11 @@ module FastlaneCore
 
     # Determines the defined data type of this ConfigItem
     def data_type
-      @data_type ? @data_type : (@is_string ? String : nil)
+      if @data_type
+        @data_type
+      else
+        (@is_string ? String : nil)
+      end
     end
 
     # Replaces the attr_accessor, but maintains the same interface

--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -11,7 +11,7 @@ module FastlaneCore
     # @param verify_block an optional block which is called when a new value is set.
     #   Check value is valid. This could be type checks or if a folder/file exists
     #   You have to raise a specific exception if something goes wrong. Append .red after the string
-    # @param is_string (Boolean) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
+    # @param is_string *DEPRECATED* (Boolean) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
     # @param type (Class) the data type of this config item. Takes precedence over `is_string`
     # @param optional (Boolean) is false by default. If set to true, also string values will not be asked to the user
     def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: false)
@@ -70,7 +70,7 @@ module FastlaneCore
       # handles class comparisons
       case data_type.to_s
       when 'Array'
-        value = value.split(',')
+        value = value.to_s.split(',')
       else
         # Special treatment if the user specififed true, false or YES, NO
         if %w(YES yes true).include?(value)

--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -89,7 +89,7 @@ module FastlaneCore
     end
 
     # Replaces the attr_accessor, but maintains the same interface
-    def is_string
+    def string?
       data_type == String
     end
 

--- a/lib/fastlane_core/configuration/configuration.rb
+++ b/lib/fastlane_core/configuration/configuration.rb
@@ -135,7 +135,7 @@ module FastlaneCore
       end
 
       value = option.default_value if value.nil?
-      value = nil if value.nil? and !option.is_string # by default boolean flags are false
+      value = nil if value.nil? and !option.string? # by default boolean flags are false
 
       return value unless value.nil? # we already have a value
       return value if option.optional # as this value is not required, just return what we have

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -59,21 +59,32 @@ describe FastlaneCore do
         end.to raise_error "Multiple entries for short_option '-f' found!".red
       end
 
-      it "parses if an array if the option is specified" do
-        verify_block = proc do |value|
-          raise 'Fail the test!' unless value.kind_of? Array
-        end
-
+      it "sets the data type correctly if `is_string` is not set but type is specified" do
         config_item = FastlaneCore::ConfigItem.new(key: :foo,
                                                    short_option: '-f',
                                                    description: 'foo',
-                                                   is_array: true,
-                                                   is_string: false,
-                                                   verify_block: verify_block)
+                                                   type: Array)
 
-        expect do
-          FastlaneCore::Configuration.create([config_item], { foo: 'abc,123,xyz,456' })
-        end.to_not raise_error
+        expect(config_item.data_type).to eq(Array)
+      end
+
+      it "sets the data type correctly if `is_string` is set but the type is specified" do
+        config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                   short_option: '-f',
+                                                   description: 'foo',
+                                                   is_string: true,
+                                                   type: Array)
+
+        expect(config_item.data_type).to eq(Array)
+      end
+
+      it "sets the data type correctly if `is_string` is set but the type is not specified" do
+        config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                   short_option: '-f',
+                                                   description: 'foo',
+                                                   is_string: true)
+
+        expect(config_item.data_type).to eq(String)
       end
 
       it "verifies the default value as well" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -87,6 +87,17 @@ describe FastlaneCore do
         expect(config_item.data_type).to eq(String)
       end
 
+      it "auto converts value to Array" do
+        config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                   short_option: '-f',
+                                                   description: 'foo',
+                                                   type: Array)
+
+        value = config_item.auto_convert_value('5,4,3,2,1')
+
+        expect(value).to eq(['5', '4', '3', '2', '1'])
+      end
+
       it "verifies the default value as well" do
         c = FastlaneCore::ConfigItem.new(key: :output,
                                   env_name: "SIGH_OUTPUT_PATH",

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -59,6 +59,23 @@ describe FastlaneCore do
         end.to raise_error "Multiple entries for short_option '-f' found!".red
       end
 
+      it "parses if an array if the option is specified" do
+        verify_block = proc do |value|
+          raise 'Fail the test!' unless value.kind_of? Array
+        end
+
+        config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                   short_option: '-f',
+                                                   description: 'foo',
+                                                   is_array: true,
+                                                   is_string: false,
+                                                   verify_block: verify_block)
+
+        expect do
+          FastlaneCore::Configuration.create([config_item], { foo: 'abc,123,xyz,456' })
+        end.to_not raise_error
+      end
+
       it "verifies the default value as well" do
         c = FastlaneCore::ConfigItem.new(key: :output,
                                   env_name: "SIGH_OUTPUT_PATH",


### PR DESCRIPTION
In response to [this](https://github.com/fastlane/fastlane_core/issues/51) issue on fastlane_core and [this](https://github.com/fastlane/snapshot/issues/341) issue on snapshot.

There are options in fastlane tools that require that an array be passed as the option (and validate so in the `verify_block`). However, fastlane_core never passes that value as an Array, it stores it as a comma delimited string.

I fixed this by parsing the comma delimited string into an array if the `:is_array` flag is set when instantiating the ConfigItem.
