### PR TITLE
Improve handling of Array configuration options

### DIFF
--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -74,7 +74,7 @@ module FastlaneCore
 
       case
       when data_type == Array
-        return value.to_s.split(',')
+        return value.split(',') if value.kind_of?(String)
       when data_type == Integer
         return value.to_i
       when data_type == Float

--- a/lib/fastlane_core/configuration/configuration.rb
+++ b/lib/fastlane_core/configuration/configuration.rb
@@ -132,7 +132,7 @@ module FastlaneCore
 
       # `if value == nil` instead of ||= because false is also a valid value
       if value.nil? and option.env_name and ENV[option.env_name]
-        value = ENV[option.env_name].dup
+        value = option.auto_convert_value(ENV[option.env_name].dup)
         option.verify!(value) if value
       end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -87,15 +87,39 @@ describe FastlaneCore do
         expect(config_item.data_type).to eq(String)
       end
 
-      it "auto converts value to Array" do
+      it "returns Array default values correctly" do
+        config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                   short_option: '-f',
+                                                   description: 'foo',
+                                                   type: Array,
+                                                   optional: true,
+                                                   default_value: ['5', '4', '3', '2', '1'])
+        config = FastlaneCore::Configuration.create([config_item], {})
+
+        expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
+      end
+
+      it "returns Array input values correctly" do
         config_item = FastlaneCore::ConfigItem.new(key: :foo,
                                                    short_option: '-f',
                                                    description: 'foo',
                                                    type: Array)
+        config = FastlaneCore::Configuration.create([config_item], { foo: ['5', '4', '3', '2', '1'] })
 
-        value = config_item.auto_convert_value('5,4,3,2,1')
+        expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
+      end
 
-        expect(value).to eq(['5', '4', '3', '2', '1'])
+      it "returns Array environment variable values correctly" do
+        ENV["FOO"] = '5,4,3,2,1'
+        config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                   short_option: '-f',
+                                                   description: 'foo',
+                                                   env_name: 'FOO',
+                                                   type: Array)
+        config = FastlaneCore::Configuration.create([config_item], {})
+
+        expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
+        ENV.delete("FOO")
       end
 
       it "auto converts string values to Integers" do


### PR DESCRIPTION
The current code is not resulting in usable `Array` values from of the `Configuration` object after handling default values or inputs returned from Commander. For example, running a command with the follow option:

``` ruby
FastlaneCore::ConfigItem.new(key: :locales,
                             description: "A list of locales which should be used",
                             short_option: "-q",
                             type: Array,
                             default_value: ['en-US'])
//...
```

and the command-line params:

``` bash
command -q en-US,fr-FR,ja-JP
```

gives me a `Configuration` object that when asked for the `:locales` key, returns:

``` ruby
["[\"en-US\"", " \"fr-FR\"", " \"ja-JP\"]"]
```

Now that Commander knows about `Array` options by their correct type, I believe we no longer need special value conversion for them in `auto_convert_value`
