### PR TITLE
Add Apple TV IPA upload support for Transporter

### DIFF
--- a/lib/assets/XMLTemplate.xml.erb
+++ b/lib/assets/XMLTemplate.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://apple.com/itunes/importer" version="software4.7">
-  <software_assets apple_id="<%= @data[:apple_id] %>">
+<package xmlns="http://apple.com/itunes/importer" version="software5.4">
+  <software_assets apple_id="<%= @data[:apple_id] %>" app_platform="<%= data[:platform] %>">
     <asset type="bundle">
       <data_file>
         <size><%= @data[:file_size] %></size>

--- a/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -20,7 +20,7 @@ module FastlaneCore
         file_size: File.size(ipa_path),
         ipa_path: File.basename(ipa_path), # this is only the base name as the ipa is inside the package
         md5: Digest::MD5.hexdigest(File.read(ipa_path))
-        platform: platform || "ios" # pass "appletvos" for Apple TV's IPA
+        platform: (platform || "ios") # pass "appletvos" for Apple TV's IPA
       }
 
       xml_path = File.join(lib_path, "lib/assets/XMLTemplate.xml.erb")

--- a/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -7,7 +7,7 @@ module FastlaneCore
 
     attr_accessor :package_path
 
-    def generate(app_id: nil, ipa_path: nil, package_path: nil)
+    def generate(app_id: nil, ipa_path: nil, package_path: nil, platform: nil)
       self.package_path = File.join(package_path, "#{app_id}.itmsp")
       FileUtils.rm_rf self.package_path if File.directory?(self.package_path)
       FileUtils.mkdir_p self.package_path
@@ -20,6 +20,7 @@ module FastlaneCore
         file_size: File.size(ipa_path),
         ipa_path: File.basename(ipa_path), # this is only the base name as the ipa is inside the package
         md5: Digest::MD5.hexdigest(File.read(ipa_path))
+        platform: platform || "ios" # pass "appletvos" for Apple TV's IPA
       }
 
       xml_path = File.join(lib_path, "lib/assets/XMLTemplate.xml.erb")

--- a/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -19,7 +19,7 @@ module FastlaneCore
         apple_id: app_id,
         file_size: File.size(ipa_path),
         ipa_path: File.basename(ipa_path), # this is only the base name as the ipa is inside the package
-        md5: Digest::MD5.hexdigest(File.read(ipa_path))
+        md5: Digest::MD5.hexdigest(File.read(ipa_path)),
         platform: (platform || "ios") # pass "appletvos" for Apple TV's IPA
       }
 


### PR DESCRIPTION
This will resolve issue 
- https://github.com/fastlane/pilot/issues/55
- https://github.com/fastlane/pilot/issues/92

Tested already.
