### PR TITLE
Allow command summary tables to display default values again

### DIFF
--- a/lib/fastlane_core/configuration/configuration.rb
+++ b/lib/fastlane_core/configuration/configuration.rb
@@ -120,7 +120,8 @@ module FastlaneCore
     #####################################################
 
     # Returns the value for a certain key. fastlane_core tries to fetch the value from different sources
-    def fetch(key)
+    # if 'ask' is true and the value is not present, the user will be prompted to provide a value
+    def fetch(key, ask: true)
       raise "Key '#{key}' must be a symbol. Example :app_id.".red unless key.kind_of?(Symbol)
 
       option = option_for_key(key)
@@ -150,7 +151,7 @@ module FastlaneCore
         raise "No value found for '#{key}'"
       end
 
-      while value.nil?
+      while ask && value.nil?
         Helper.log.info "To not be asked about this value, you can specify it using '#{option.key}'".yellow
         value = ask("#{option.description}: ")
         # Also store this value to use it from now on

--- a/lib/fastlane_core/print_table.rb
+++ b/lib/fastlane_core/print_table.rb
@@ -8,7 +8,7 @@ module FastlaneCore
         rows = []
 
         config.available_options.each do |config_item|
-          value = config._values[config_item.key] # using `_values` here to not ask the user for missing values at this point
+          value = config.fetch(config_item.key, ask: false) # Don't ask the user for missing values at this point
           next if value.nil?
           next if value.to_s == ""
           next if hide_keys.include?(config_item.key)


### PR DESCRIPTION
When `print_table` changed to access a `Configuration`'s `_values` it lost the ability to display options that were getting their values from the defaults.

This adds an optional named parameter to `fetch` called `ask`. It defaults to `true` to keep all calling code experiencing the previous behavior by default. For `print_table`, however, we will pass `ask: false` to prevent fetching values from triggering an interactive prompt at that time.
