### PR TITLE
Perform basic type validation within ConfigItem

### DIFF
--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -51,8 +51,9 @@ module FastlaneCore
     def valid?(value)
       # we also allow nil values, which do not have to be verified.
       if value
-        if string?
-          raise "'#{self.key}' value must be a String! Found #{value.class} instead.".red unless value.kind_of? String
+        # Verify that value is the type that we're expecting, if we are expecting a type
+        if data_type && !value.kind_of?(data_type)
+          raise "'#{self.key}' value must be a #{data_type}! Found #{value.class} instead.".red
         end
 
         if @verify_block

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -144,6 +144,17 @@ describe FastlaneCore do
         expect(value).to eq(9.91)
       end
 
+      it "raises an exception if the data type is not as expected" do
+        config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                   short_option: '-f',
+                                                   description: 'foo',
+                                                   type: Float)
+
+        expect do
+          config_item.valid?('ABC')
+        end.to raise_error
+      end
+
       it "verifies the default value as well" do
         c = FastlaneCore::ConfigItem.new(key: :output,
                                   env_name: "SIGH_OUTPUT_PATH",


### PR DESCRIPTION
In response to this https://github.com/fastlane/snapshot/pull/354#discussion_r47984694.

This performs basic type validation (ensuring that `value.class` matches `data_type`) within ConfigItem.
