### PR TITLE
Use the scheme matching the project name

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -20,6 +20,10 @@ describe FastlaneCore do
         expect(@project.is_workspace).to eq(false)
       end
 
+      it "#project_name" do
+        expect(@project.project_name).to eq("Example")
+      end
+
       it "#schemes returns all available schemes" do
         expect(@project.schemes).to eq(["Example"])
       end


### PR DESCRIPTION
If the `AUTOMATED_SCHEME_SELECTION` environment variable is set, the scheme matching the project name will be used.
This will allow for most of the projects to run `gym` or `scan` without specifying the scheme. It will be useful for "generic" scripts that run against multiple projects.
