### PR TITLE
Fix reference to Helper.colors_disabled?

### DIFF
--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -90,7 +90,7 @@ module FastlaneCore
     # rubocop:enable Style/PredicateName
 
     # Do we want to disable the colored output?
-    def colors_disabled?
+    def self.colors_disabled?
       ENV["FASTLANE_DISABLE_COLORS"]
     end
 

--- a/lib/fastlane_core/ui/ui.rb
+++ b/lib/fastlane_core/ui/ui.rb
@@ -23,4 +23,4 @@ Dir[File.expand_path('implementations/*.rb', File.dirname(__FILE__))].each do |f
   require file
 end
 
-require 'fastlane_core/ui/disable_colors' if Helper.colors_disabled?
+require 'fastlane_core/ui/disable_colors' if FastlaneCore::Helper.colors_disabled?


### PR DESCRIPTION
This is currently causing

```
/Users/mfurtak/Documents/Programming/Ruby/countdown/fastlane_core/lib/fastlane_core/ui/ui.rb:26:in `<top (required)>': uninitialized constant Helper (NameError)
    from /Users/mfurtak/Documents/Programming/Ruby/countdown/fastlane_core/lib/fastlane_core.rb:18:in `require'
    from /Users/mfurtak/Documents/Programming/Ruby/countdown/fastlane_core/lib/fastlane_core.rb:18:in `<top (required)>'
    from /Users/mfurtak/Documents/Programming/Ruby/countdown/fastlane/lib/fastlane.rb:18:in `require'
    from /Users/mfurtak/Documents/Programming/Ruby/countdown/fastlane/lib/fastlane.rb:18:in `<top (required)>'
    from bin/fastlane:6:in `require'
    from bin/fastlane:6:in `<main>'
```

when running any fastlane command
