### PR TITLE
Add which() to CommandExecutor for finding commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 FastlaneCore
 ============
 
-[![Twitter: @KauseFx](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools)
+[![Twitter: @FastlaneTools](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools)
 [![License](http://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/fastlane/fastlane_core/blob/master/LICENSE)
 [![Gem](https://img.shields.io/gem/v/fastlane_core.svg?style=flat)](http://rubygems.org/gems/fastlane_core)
 [![Build Status](https://img.shields.io/travis/fastlane/fastlane_core/master.svg?style=flat)](https://travis-ci.org/fastlane/fastlane_core)

--- a/lib/fastlane_core/command_executor.rb
+++ b/lib/fastlane_core/command_executor.rb
@@ -2,6 +2,27 @@ module FastlaneCore
   # Executes commands and takes care of error handling and more
   class CommandExecutor
     class << self
+      # Cross-platform way of finding an executable in the $PATH. Respects the $PATHEXT, which lists
+      # valid file extensions for executables on Windows.
+      #
+      #    which('ruby') #=> /usr/bin/ruby
+      #
+      # Derived from http://stackoverflow.com/a/5471032/3005
+      def which(cmd)
+        # PATHEXT contains the list of file extensions that Windows considers executable, semicolon separated.
+        # e.g. ".COM;.EXE;.BAT;.CMD"
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+
+        ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+          exts.each do |ext|
+            cmd_path = File.join(path, "#{cmd}#{ext}")
+            return cmd_path if File.executable?(cmd_path) && !File.directory?(cmd_path)
+          end
+        end
+
+        return nil
+      end
+
       # @param command [String] The command to be executed
       # @param print_all [Boolean] Do we want to print out the command output while running?
       # @param print_command [Boolean] Should we print the command that's being executed

--- a/spec/command_executor_spec.rb
+++ b/spec/command_executor_spec.rb
@@ -1,0 +1,50 @@
+describe FastlaneCore do
+  describe FastlaneCore::CommandExecutor do
+    describe "which" do
+      require 'tempfile'
+
+      it "does not find commands which are not on the PATH" do
+        expect(FastlaneCore::CommandExecutor.which('not_a_real_command')).to be_nil
+      end
+
+      it "finds commands without extensions which are on the PATH" do
+        Tempfile.create('foobarbaz') do |f|
+          File.chmod(0777, f)
+
+          temp_dir = File.dirname(f)
+          temp_cmd = File.basename(f)
+
+          with_env_values('PATH' => temp_dir) do
+            expect(FastlaneCore::CommandExecutor.which(temp_cmd)).to eq(f.path)
+          end
+        end
+      end
+
+      it "finds commands with known extensions which are on the PATH" do
+        Tempfile.create(['foobarbaz', '.exe']) do |f|
+          File.chmod(0777, f)
+
+          temp_dir = File.dirname(f)
+          temp_cmd = File.basename(f, '.exe')
+
+          with_env_values('PATH' => temp_dir, 'PATHEXT' => '.exe') do
+            expect(FastlaneCore::CommandExecutor.which(temp_cmd)).to eq(f.path)
+          end
+        end
+      end
+
+      it "does not find commands with unknown extensions which are on the PATH" do
+        Tempfile.create(['foobarbaz', '.exe']) do |f|
+          File.chmod(0777, f)
+
+          temp_dir = File.dirname(f)
+          temp_cmd = File.basename(f, '.exe')
+
+          with_env_values('PATH' => temp_dir, 'PATHEXT' => '') do
+            expect(FastlaneCore::CommandExecutor.which(temp_cmd)).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,19 @@ module SpecHelper
 end
 
 WebMock.disable_net_connect!(allow: 'coveralls.io')
+
+# Executes the provided block after adjusting the ENV to have the
+# provided keys and values set as defined in hash. After the block
+# completes, restores the ENV to its previous state.
+def with_env_values(hash)
+  old_vals = ENV.select { |k, v| hash.include?(k) }
+  hash.each do |k, v|
+    ENV[k] = hash[k]
+  end
+  yield
+ensure
+  hash.each do |k, v|
+    ENV.delete(k) unless old_vals.include?(k)
+    ENV[k] = old_vals[k]
+  end
+end


### PR DESCRIPTION
Add a cross-platform way of finding an executable in the $PATH. Respects the $PATHEXT, which lists valid file extensions for executables on Windows.
