### PR TITLE
Fixed the issue where the given path of the provisioning profile has single quotes.

### DIFF
--- a/lib/fastlane_core/provisioning_profile.rb
+++ b/lib/fastlane_core/provisioning_profile.rb
@@ -24,7 +24,7 @@ module FastlaneCore
       def parse(path)
         require 'plist'
 
-        plist = Plist.parse_xml(`security cms -D -i '#{path}'`)
+        plist = Plist.parse_xml(`security cms -D -i "#{path}"`)
         if (plist || []).count > 5
           plist
         else


### PR DESCRIPTION
This solves the issue where the `path` of the `parse` method of ProvisioningProfile contains single quote characters. For example, if the path of my provisioning profile is `/Users/user/Apple's Mobile App/development.mobileprovision`. The following error would occur without this fix. 

``` bash
sh: -c: line 0: unexpected EOF while looking for matching `''
sh: -c: line 1: syntax error: unexpected end of file
```
