### PR TITLE
Added gitlab-ci to known CI environments

### DIFF
--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -63,7 +63,7 @@ module FastlaneCore
     # @return [boolean] true if building in a known CI environment
     def self.ci?
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey'].each do |current|
+      ['JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI'].each do |current|
         return true if ENV.key?(current)
       end
       return false

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -15,6 +15,11 @@ describe FastlaneCore do
         stub_const('ENV', { 'TRAVIS' => true })
         expect(FastlaneCore::Helper.is_ci?).to be true
       end
+      
+      it "returns true when building in gitlab-ci" do
+        stub_const('ENV', { 'GITLAB_CI' => true })
+        expect(FastlaneCore::Helper.is_ci?).to be true
+      end
     end
 
     # Mac OS only (to work on Linux)


### PR DESCRIPTION
As CI is now fully integrated in gitlab, (known as gitlab-ci) it would be useful, that the action is_ci checks also for the gitlab ENV variable to get the same functionality as with JENKINS or TRAVIS.
And because gitlab (as an alternative to github) grows more and more, it would be useful to share our changes to everyone.

Changed code details:
gitlab-ci sets an ENV variable `GITLAB_CI` when running, similar to `TRAVIS`.
This is now also checked. 
