### PR TITLE
[New Exceptions] Main PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ This gem contains all shared classes and code:
 
 You can hide the inline changelog by setting the `FASTLANE_HIDE_CHANGELOG` environment variable
 
+# Code of Conduct
+Help us keep `fastlane` open and inclusive. Please read and follow our [Code of Conduct](https://github.com/fastlane/code-of-conduct).
+
 # License
 This project is licensed under the terms of the MIT license. See the LICENSE file.
 

--- a/fastlane_core.gemspec
+++ b/fastlane_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json' # Because sometimes it's just not installed
   spec.add_dependency 'highline', '>= 1.7.2' # user inputs (e.g. passwords)
   spec.add_dependency 'colored' # coloured terminal output
-  spec.add_dependency 'commander', '>= 4.3.5' # CLI parser
+  spec.add_dependency 'commander', '= 4.3.5' # CLI parser
   spec.add_dependency 'babosa' # transliterate strings
   spec.add_dependency 'excon', '~> 0.45.0' # Great HTTP Client
   spec.add_dependency 'rubyzip', '~> 1.1.6' # needed for extracting the ipa file
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 1.19.0'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'fastlane'
-  spec.add_development_dependency 'rubocop', '~> 0.34'
+  spec.add_development_dependency 'rubocop', '~> 0.35.1'
   spec.add_development_dependency 'danger', '>= 0.1.1'
 end

--- a/lib/fastlane_core.rb
+++ b/lib/fastlane_core.rb
@@ -24,5 +24,8 @@ require 'fastlane_core/ui/ui'
 require 'colored'
 require 'commander'
 
+# after commander import
+require 'fastlane_core/ui/fastlane_runner' # monkey patch
+
 module FastlaneCore
 end

--- a/lib/fastlane_core/crash_reporting/crash_reporting.rb
+++ b/lib/fastlane_core/crash_reporting/crash_reporting.rb
@@ -27,7 +27,6 @@ module FastlaneCore
         puts "😨  An error occured. Please enable crash reports using `fastlane enable_crash_reporting`.".yellow
         puts "👍  This makes resolving issues much easier and helps improve fastlane.".yellow
         puts "🔒  The reports will be stored securely on getsentry.com.".yellow
-        puts "✨  Once crash reporting is enabled, you get a clean output when something goes wrong.".yellow
         puts "🙊  More information about privacy: https://github.com/fastlane/fastlane/releases/tag/1.33.3".yellow
         puts "-------------------------------------------------------------------------------------------".yellow
       end
@@ -40,7 +39,6 @@ module FastlaneCore
         puts "😃  Enable crash reporting when fastlane experiences a problem?".yellow
         puts "👍  This makes resolving issues much easier and helps improve fastlane.".yellow
         puts "🔒  The reports will be stored securely on getsentry.com".yellow
-        puts "✨  Once crash reporting is enabled, you get a clean output when something goes wrong".yellow
         puts "🙊  More information about privacy: https://github.com/fastlane/fastlane/releases/tag/1.33.3".yellow
         puts "🌴  You can always disable crash reports at anytime `fastlane disable_crash_reporting`".yellow
         puts "-------------------------------------------------------------------------------------------".yellow
@@ -52,13 +50,10 @@ module FastlaneCore
       def handle_crash(ex)
         unless enabled?
           show_message
-          raise ex
         end
 
         raise ex if Helper.test?
-
         send_crash(ex)
-        Kernel.abort # => return status 1, we could pass a message here too, but this would end up with duplicates
       end
 
       def send_crash(ex)

--- a/lib/fastlane_core/helper.rb
+++ b/lib/fastlane_core/helper.rb
@@ -63,7 +63,7 @@ module FastlaneCore
     # @return [boolean] true if building in a known CI environment
     def self.ci?
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey'].each do |current|
+      ['JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI'].each do |current|
         return true if ENV.key?(current)
       end
       return false

--- a/lib/fastlane_core/ipa_file_analyser.rb
+++ b/lib/fastlane_core/ipa_file_analyser.rb
@@ -19,25 +19,23 @@ module FastlaneCore
 
     def self.fetch_info_plist_file(path)
       Zip::File.open(path) do |zipfile|
-        zipfile.each do |file|
-          next if file.name.match(%r{\.app/.+\.app/Info.plist$})
-          next unless file.name.include? '.plist' and !['.bundle', '.framework'].any? { |a| file.name.include? a }
+        file = zipfile.glob('**/Payload/*.app/Info.plist').first
+        return nil unless file
 
-          # We can not be completely sure, that's the correct plist file, so we have to try
-          begin
-            # The XML file has to be properly unpacked first
-            tmp_path = "/tmp/deploytmp.plist"
-            File.write(tmp_path, zipfile.read(file))
-            system("plutil -convert xml1 #{tmp_path}")
-            result = Plist.parse_xml(tmp_path)
-            File.delete(tmp_path)
+        # We can not be completely sure, that's the correct plist file, so we have to try
+        begin
+          # The XML file has to be properly unpacked first
+          tmp_path = "/tmp/deploytmp.plist"
+          File.write(tmp_path, zipfile.read(file))
+          system("plutil -convert xml1 #{tmp_path}")
+          result = Plist.parse_xml(tmp_path)
+          File.delete(tmp_path)
 
-            if result['CFBundleIdentifier'] or result['CFBundleVersion']
-              return result
-            end
-          rescue
-            # We don't really care, look for another XML file
+          if result['CFBundleIdentifier'] or result['CFBundleVersion']
+            return result
           end
+        rescue
+          # We don't really care, look for another XML file
         end
       end
 

--- a/lib/fastlane_core/itunes_transporter.rb
+++ b/lib/fastlane_core/itunes_transporter.rb
@@ -56,12 +56,7 @@ module FastlaneCore
       if result and File.directory? itmsp_path
         Helper.log.info "Successfully downloaded the latest package from iTunesConnect.".green
       else
-        # rubocop:disable Style/CaseEquality
-        unless /^[0-9a-zA-Z\.\$\_]*$/ === @password
-          Helper.log.error "Password contains special characters, which may not be handled properly by iTMSTransporter. If you experience problems uploading to iTunes Connect, please consider changing your password to something with only alphanumeric characters."
-        end
-        # rubocop:enable Style/CaseEquality
-        Helper.log.fatal "Could not download metadata from iTunes Connect! It's probably related to your password or your internet connection."
+        handle_error(@password)
       end
 
       result
@@ -90,12 +85,23 @@ module FastlaneCore
         Helper.log.info(("-" * 102).green)
 
         FileUtils.rm_rf(dir) unless Helper.is_test? # we don't need the package any more, since the upload was successful
+      else
+        handle_error(@password)
       end
 
       result
     end
 
     private
+
+    def handle_error(password)
+      # rubocop:disable Style/CaseEquality
+      unless /^[0-9a-zA-Z\.\$\_]*$/ === password
+        Helper.log.error "Password contains special characters, which may not be handled properly by iTMSTransporter. If you experience problems uploading to iTunes Connect, please consider changing your password to something with only alphanumeric characters."
+      end
+      # rubocop:enable Style/CaseEquality
+      Helper.log.fatal "Could not download/upload from iTunes Connect! It's probably related to your password or your internet connection."
+    end
 
     def execute_transporter(command)
       @errors = []

--- a/lib/fastlane_core/project.rb
+++ b/lib/fastlane_core/project.rb
@@ -86,7 +86,9 @@ module FastlaneCore
     end
 
     # Let the user select a scheme
-    def select_scheme
+    # Use a scheme containing the preferred_to_include string when multiple schemes were found
+    # rubocop:disable Metrics/AbcSize
+    def select_scheme(preferred_to_include: nil)
       if options[:scheme].to_s.length > 0
         # Verify the scheme is available
         unless schemes.include?(options[:scheme].to_s)
@@ -100,13 +102,22 @@ module FastlaneCore
       if schemes.count == 1
         options[:scheme] = schemes.last
       elsif schemes.count > 1
-        if Helper.is_ci?
-          Helper.log.error "Multiple schemes found but you haven't specified one.".red
-          Helper.log.error "Since this is a CI, please pass one using the `scheme` option".red
-          raise "Multiple schemes found".red
+        preferred = nil
+        if preferred_to_include
+          preferred = schemes.find_all { |a| a.downcase.include?(preferred_to_include.downcase) }
+        end
+
+        if preferred_to_include and preferred.count == 1
+          options[:scheme] = preferred.last
         else
-          puts "Select Scheme: "
-          options[:scheme] = choose(*(schemes))
+          if Helper.is_ci?
+            Helper.log.error "Multiple schemes found but you haven't specified one.".red
+            Helper.log.error "Since this is a CI, please pass one using the `scheme` option".red
+            raise "Multiple schemes found".red
+          else
+            puts "Select Scheme: "
+            options[:scheme] = choose(*(schemes))
+          end
         end
       else
         Helper.log.error "Couldn't find any schemes in this project, make sure that the scheme is shared if you are using a workspace".red
@@ -115,6 +126,7 @@ module FastlaneCore
         raise "No Schemes found".red
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Get all available configurations in an array
     def configurations
@@ -177,7 +189,7 @@ module FastlaneCore
     # Get the build settings for our project
     # this is used to properly get the DerivedData folder
     # @param [String] The key of which we want the value for (e.g. "PRODUCT_NAME")
-    def build_settings(key: nil, optional: true, silent: false)
+    def build_settings(key: nil, optional: true)
       unless @build_settings
         # We also need to pass the workspace and scheme to this command
         command = "xcrun xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}"
@@ -198,9 +210,9 @@ module FastlaneCore
     end
 
     # Returns the build settings and sets the default scheme to the options hash
-    def default_build_settings(key: nil, optional: true, silent: false)
+    def default_build_settings(key: nil, optional: true)
       options[:scheme] = schemes.first if is_workspace
-      build_settings(key: key, optional: optional, silent: silent)
+      build_settings(key: key, optional: optional)
     end
 
     def raw_info(silent: false)

--- a/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/lib/fastlane_core/ui/fastlane_runner.rb
@@ -1,0 +1,53 @@
+module Commander
+  # This class override the run method with our custom stack trace handling
+  # In particular we want to distinguish between user_error! and crash! (one with, one without stack trace)
+  class Runner
+    # Code taken from https://github.com/commander-rb/commander/blob/master/lib/commander/runner.rb#L50
+    def run!
+      require_program :version, :description
+      trap('INT') { abort program(:int_message) } if program(:int_message)
+      trap('INT') { program(:int_block).call } if program(:int_block)
+      global_option('-h', '--help', 'Display help documentation') do
+        args = @args - %w(-h --help)
+        command(:help).run(*args)
+        return
+      end
+      global_option('-v', '--version', 'Display version information') do
+        say version
+        return
+      end
+      parse_global_options
+      remove_global_options options, @args
+
+      begin
+        run_active_command
+      rescue InvalidCommandError => e
+        abort "#{e}. Use --help for more information"
+      rescue Interrupt => ex
+        # We catch it so that the stack trace is hidden by default when using ctrl + c
+        if $verbose
+          raise ex
+        else
+          puts "\nCancelled... use --verbose to show the stack trace"
+        end
+      rescue \
+        OptionParser::InvalidOption,
+        OptionParser::InvalidArgument,
+        OptionParser::MissingArgument => e
+        abort e.to_s
+      rescue FastlaneCore::Interface::FastlaneError => e # user_error!
+        error_message = "\n[!] #{e}".red
+        if $verbose # with stack trace
+          raise e, "[!] #{e.message}".red, e.backtrace
+        else
+          abort error_message # without stack trace
+        end
+      rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
+        FastlaneCore::CrashReporting.handle_crash(ex)
+        # From https://stackoverflow.com/a/4789702/445598
+        # We do this to make the actual error message red and therefore more visible
+        raise e, "[!] #{e.message}".red, e.backtrace
+      end
+    end
+  end
+end

--- a/lib/fastlane_core/ui/implementations/shell.rb
+++ b/lib/fastlane_core/ui/implementations/shell.rb
@@ -102,36 +102,6 @@ module FastlaneCore
       ask(message.yellow) { |q| q.echo = "*" }
     end
 
-    #####################################################
-    # @!group Errors: Different kinds of exceptions
-    #####################################################
-
-    def crash!(exception)
-      if exception.kind_of?(String)
-        raise exception.red
-      elsif exception.kind_of?(Exception)
-        # From https://stackoverflow.com/a/4789702/445598
-        # We do this to make the actual error message red and therefore more visible
-        begin
-          raise exception
-        rescue => ex
-          raise $!, "[!] #{ex.message}".red, $!.backtrace
-        end
-      else
-        raise exception # we're just raising whatever we have here #yolo
-      end
-    end
-
-    def user_error!(error_message)
-      error_message = "\n[!] #{error_message}".red
-      if $verbose
-        # On verbose we want to see the full stack trace
-        raise error_message
-      else
-        abort(error_message)
-      end
-    end
-
     private
 
     def verify_interactive!(message)

--- a/lib/fastlane_core/ui/interface.rb
+++ b/lib/fastlane_core/ui/interface.rb
@@ -104,23 +104,32 @@ module FastlaneCore
     # @!group Errors: Different kinds of exceptions
     #####################################################
 
+    # raised from crash!
+    class FastlaneCrash < StandardError
+    end
+
+    # raised from user_error!
+    class FastlaneError < StandardError
+    end
+
     # Pass an exception to this method to exit the program
     #   using the given exception
     # Use this method instead of user_error! if this error is
     # unexpected, e.g. an invalid server response that shouldn't happen
-    def crash!(_exception)
-      not_implemented(__method__)
+    def crash!(exception)
+      raise FastlaneCrash.new, exception.to_s
     end
 
     # Use this method to exit the program because of an user error
     #   e.g. app doesn't exist on the given Developer Account
     #        or invalid user credentials
+    #        or scan tests fail
     # This will show the error message, but doesn't show the full
     #   stack trace
     # Basically this should be used when you actively catch the error
     # and want to show a nice error message to the user
-    def user_error!(_error_message)
-      not_implemented(__method__)
+    def user_error!(error_message)
+      raise FastlaneError.new, error_message.to_s
     end
 
     #####################################################

--- a/lib/fastlane_core/version.rb
+++ b/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.34.0"
+  VERSION = "0.35.1"
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,25 +4,25 @@ describe FastlaneCore do
       it "raises an error if no hash is given" do
         expect do
           FastlaneCore::Configuration.create([], "string")
-        end.to raise_error "values parameter must be a hash".red
+        end.to raise_error "values parameter must be a hash"
       end
 
       it "raises an error if no array is given" do
         expect do
           FastlaneCore::Configuration.create("string", {})
-        end.to raise_error "available_options parameter must be an array of ConfigItems but is String".red
+        end.to raise_error "available_options parameter must be an array of ConfigItems but is String"
       end
 
       it "raises an error if array contains invalid elements" do
         expect do
           FastlaneCore::Configuration.create(["string"], {})
-        end.to raise_error "available_options parameter must be an array of ConfigItems. Found String.".red
+        end.to raise_error "available_options parameter must be an array of ConfigItems. Found String."
       end
 
       it "raises an error if the option of a given value is not available" do
         expect do
           FastlaneCore::Configuration.create([], { cert_name: "value" })
-        end.to raise_error "Could not find option 'cert_name' in the list of available options: ".red
+        end.to raise_error "Could not find option 'cert_name' in the list of available options: "
       end
 
       it "raises an error if a description ends with a ." do
@@ -42,7 +42,7 @@ describe FastlaneCore do
                                               FastlaneCore::ConfigItem.new(
                                                 key: :cert_name,
                                            env_name: "asdf")], {})
-        end.to raise_error "Multiple entries for configuration key 'cert_name' found!".red
+        end.to raise_error "Multiple entries for configuration key 'cert_name' found!"
       end
 
       it "raises an error if a a short_option was used twice" do
@@ -54,9 +54,106 @@ describe FastlaneCore do
                                        short_option: "-f",
                                        description: "bar")
         ]
+
         expect do
           FastlaneCore::Configuration.create(conflicting_options, {})
-        end.to raise_error "Multiple entries for short_option '-f' found!".red
+        end.to raise_error "Multiple entries for short_option '-f' found!"
+      end
+
+      it "raises an error for unresolved conflict between options" do
+        conflicting_options = [
+          FastlaneCore::ConfigItem.new(key: :foo,
+                                       short_option: "-f",
+                                       conflicting_options: [:bar, :oof]),
+          FastlaneCore::ConfigItem.new(key: :bar,
+                                       short_option: "-b"),
+          FastlaneCore::ConfigItem.new(key: :oof,
+                                       short_option: "-o")
+        ]
+
+        values = {
+            foo: "",
+            bar: ""
+        }
+
+        expect do
+          FastlaneCore::Configuration.create(conflicting_options, values)
+        end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
+      end
+
+      it "calls custom conflict handler when conflict happens between two options" do
+        conflicting_options = [
+          FastlaneCore::ConfigItem.new(key: :foo,
+                                       short_option: "-f",
+                                       conflicting_options: [:bar, :oof],
+                                       conflict_block: proc do |value|
+                                         raise "You can't use option '#{value.short_option}' along with '-f'"
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :bar,
+                                       short_option: "-b"),
+          FastlaneCore::ConfigItem.new(key: :oof,
+                                       short_option: "-o",
+                                       conflict_block: proc do |value|
+                                         raise "You can't use option '#{value.short_option}' along with '-o'"
+                                       end)
+        ]
+
+        values = {
+            foo: "",
+            bar: ""
+        }
+
+        expect do
+          FastlaneCore::Configuration.create(conflicting_options, values)
+        end.to raise_error "You can't use option '-b' along with '-f'"
+      end
+
+      it "raises an error for unresolved conflict between options" do
+        conflicting_options = [
+          FastlaneCore::ConfigItem.new(key: :foo,
+                                       short_option: "-f",
+                                       conflicting_options: [:bar, :oof]),
+          FastlaneCore::ConfigItem.new(key: :bar,
+                                       short_option: "-b"),
+          FastlaneCore::ConfigItem.new(key: :oof,
+                                       short_option: "-o")
+        ]
+
+        values = {
+            foo: "",
+            bar: ""
+        }
+
+        expect do
+          FastlaneCore::Configuration.create(conflicting_options, values)
+        end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
+      end
+
+      it "calls custom conflict handler when conflict happens between two options" do
+        conflicting_options = [
+          FastlaneCore::ConfigItem.new(key: :foo,
+                                       short_option: "-f",
+                                       conflicting_options: [:bar, :oof],
+                                       conflict_block: proc do |value|
+                                         raise "You can't use option '#{value.short_option}' along with '-f'".red
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :bar,
+                                       short_option: "-b"),
+          FastlaneCore::ConfigItem.new(key: :oof,
+                                       short_option: "-o",
+                                       conflict_block: proc do |value|
+                                         raise "You can't use option '#{value.short_option}' along with '-o'".red
+                                       end)
+        ]
+
+        values = {
+            foo: "",
+            bar: ""
+        }
+
+        expect do
+          FastlaneCore::Configuration.create(conflicting_options, values)
+        end.to raise_error "You can't use option '-b' along with '-f'".red
       end
 
       it "sets the data type correctly if `is_string` is not set but type is specified" do
@@ -165,7 +262,7 @@ describe FastlaneCore do
                               end)
         expect do
           @config = FastlaneCore::Configuration.create([c], {})
-        end.to raise_error "Invalid default value for output, doesn't match verify_block".red
+        end.to raise_error "Invalid default value for output, doesn't match verify_block"
       end
 
       it "supports options without 'env_name'" do
@@ -243,7 +340,7 @@ describe FastlaneCore do
                                  description: "Directory in which the profile should be stored",
                                default_value: ".",
                                 verify_block: proc do |value|
-                                  raise "Could not find output directory '#{value}'".red unless File.exist?(value)
+                                  raise "Could not find output directory '#{value}'" unless File.exist?(value)
                                 end)
           ]
           @values = {
@@ -278,13 +375,13 @@ describe FastlaneCore do
           it "raises an error if a non symbol was given" do
             expect do
               @config.fetch(123)
-            end.to raise_error "Key '123' must be a symbol. Example :app_id.".red
+            end.to raise_error "Key '123' must be a symbol. Example :app_id."
           end
 
           it "raises an error if this option does not exist" do
             expect do
               @config[:asdfasdf]
-            end.to raise_error "Could not find option for key :asdfasdf. Available keys: cert_name, output".red
+            end.to raise_error "Could not find option for key :asdfasdf. Available keys: cert_name, output"
           end
 
           it "returns the value for the given key if given" do
@@ -305,13 +402,13 @@ describe FastlaneCore do
           it "throws an error if the key doesn't exist" do
             expect do
               @config.set(:non_existing, "value")
-            end.to raise_error("Could not find option 'non_existing' in the list of available options: cert_name, output".red)
+            end.to raise_error("Could not find option 'non_existing' in the list of available options: cert_name, output")
           end
 
           it "throws an error if it's invalid" do
             expect do
               @config.set(:output, 132)
-            end.to raise_error("'output' value must be a String! Found Fixnum instead.".red)
+            end.to raise_error("'output' value must be a String! Found Fixnum instead.")
           end
 
           it "allows valid updates" do

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -15,6 +15,11 @@ describe FastlaneCore do
         stub_const('ENV', { 'TRAVIS' => true })
         expect(FastlaneCore::Helper.is_ci?).to be true
       end
+
+      it "returns true when building in gitlab-ci" do
+        stub_const('ENV', { 'GITLAB_CI' => true })
+        expect(FastlaneCore::Helper.is_ci?).to be true
+      end
     end
 
     # Mac OS only (to work on Linux)


### PR DESCRIPTION
This PR changes the way exceptions are raised and handled

When calling `UI.user_error` this will now print out this really beautiful error message, with no stack trace. The user can optionally use the `--verbose` option to show the full stack trace.

<img width="1046" alt="screenshot 2016-01-22 16 51 33" src="https://cloud.githubusercontent.com/assets/869950/12527225/61838c32-c12c-11e5-934b-f33c6a743ece.png">

When there is an unexpected error/crash, the user will get the full stack trace as seen below
<img width="1046" alt="screenshot 2016-01-22 16 33 21" src="https://cloud.githubusercontent.com/assets/869950/12527221/5ca894dc-c12c-11e5-8951-ed5b3e7ae96e.png">

The `fastlane_runner` class must be imported, and it will monkey patch a method in the `commander` gem to have custom exception handling. To be 100% sure I also froze the `commander` dependency.
### Connected PRs:
- https://github.com/fastlane/scan/pull/84
- https://github.com/fastlane/fastlane/pull/1007
### To test it:
- Install the new `fastlane_core`
- Install the new `scan`
- Go to any project with a `Fastfile` and have a lane with just `scan`
- The project's tests should fail, add a wrong assert
- Run `fastlane test` and make sure to get a nice output with just the error message without stack trace
- Run `fastlane test --verbose` and see if you can see the stack trace

After calling from within `fastlane`, try this
- Call `scan` directly and get a nice error message
- Call `scan --verbose` to get the stack trace
### Other tools

When installing the new `fastlane_core` you can start using `UI.user_error!` and `UI.crash!` and it should work for free, no other changes needed
