### PR TITLE
[WIP] - try to bugfix option parsing

### DIFF
--- a/lib/fastlane_core/configuration/commander_generator.rb
+++ b/lib/fastlane_core/configuration/commander_generator.rb
@@ -67,7 +67,7 @@ module FastlaneCore
       raise "-v is already used for the version (key #{option.key})".red if short_switch == "-v"
       raise "-h is already used for the help screen (key #{option.key})".red if short_switch == "-h"
       raise "-t is already used for the trace screen (key #{option.key})".red if short_switch == "-t"
-
+      short_option = short_option.nil? ? "" : short_option
       used_switches << short_switch
     end
   end


### PR DESCRIPTION
this one try's to fix the bug when an option is set with no `short_option`

resulting in an exception:

```
config_item.rb:66:in `valid?': 'devices' value must be a String! Found TrueClass instead. (RuntimeError)
```

be carefull, i think this should pass a full range of CI runs.
because it may change configitem behaviour.

if `is_string` is not set to `false` - than options are treated as string options.
i know this is a potential-bummer, but i think in the long run, its better to have options NOT to require a short flag, as they are limited, and often not needed - and result in stupid short optionflags just to fullfill the requirement!

any ideas, when the whole travis stuff is fixed?

here is a sample - working totally without short options :bomb: 

``` ruby
#!/usr/bin/env ruby

#$:.push File.expand_path("lib", __FILE__)

require 'fastlane_core'
require 'commander'

HighLine.track_eof = false

class Demo
  include Commander::Methods

  def run
    program :version, "1.0"
    program :description, 'Demo Showcasing string cmd line arg bug'
    program :help, 'Author', 'hjanuschka'
    program :help_formatter, :compact


    always_trace!

    all_opts = [
      FastlaneCore::ConfigItem.new(key: :long_option_only_string,
                                   description: "desc",
                                   is_string: true,
                                   default_value: "asdd",
                                   optional: true),
      FastlaneCore::ConfigItem.new(key: :bool,
                                   description: "desc",
                                   default_value: false,
                                   is_string: false),
      FastlaneCore::ConfigItem.new(key: :demo_bool,
                                   description: "desc",
                                   default_value: false
                                   ),
      FastlaneCore::ConfigItem.new(key: :string_with_verify,
                                   description: "Mac",
                                   verify_block: proc do |value|
                                     raise "Invalid identifier '#{value}'" unless value.split('.').count == 3
                                   end)
    ]

    FastlaneCore::CommanderGenerator.new.generate(all_opts)

    command :run do |c|
      c.syntax = 'snapshot'
      c.description = 'Take new screenshots based on the Snapfile.'

      c.action do |args, options|
        o = options.__hash__.dup
        puts "#{o.inspect}"
        config = FastlaneCore::Configuration.create(all_opts, o)
      end
    end

    default_command :run

    run!
  end
  def config=(value)
      @config = value
      DetectValues.set_additional_default_values
  end
end

begin
  Demo.new.run
end
```

run like:

```
./demo.rb --long_option_only_string  dasas --bool --string_with_verify asdads.asd.d
{:long_option_only_string=>"dasas", :bool=>true, :string_with_verify=>"asdads.asd.d"}
```

what do you think?

some issues that where triggered by this bug:
- https://github.com/fastlane/produce/issues/77
- https://github.com/fastlane/scan/issues/71
- https://github.com/fastlane/supply/issues/12

/cc @KrauseFx 
