### PR TITLE
Changed Info.plist path using glob instead of iterating to find the correct plist

### DIFF
--- a/lib/fastlane_core/ipa_file_analyser.rb
+++ b/lib/fastlane_core/ipa_file_analyser.rb
@@ -19,25 +19,23 @@ module FastlaneCore
 
     def self.fetch_info_plist_file(path)
       Zip::File.open(path) do |zipfile|
-        zipfile.each do |file|
-          next if file.name.match(%r{\.app/.+\.app/Info.plist$})
-          next unless file.name.include? '.plist' and !['.bundle', '.framework'].any? { |a| file.name.include? a }
+        file = zipfile.glob('**/Payload/*.app/Info.plist').first
+        return nil unless file
 
-          # We can not be completely sure, that's the correct plist file, so we have to try
-          begin
-            # The XML file has to be properly unpacked first
-            tmp_path = "/tmp/deploytmp.plist"
-            File.write(tmp_path, zipfile.read(file))
-            system("plutil -convert xml1 #{tmp_path}")
-            result = Plist.parse_xml(tmp_path)
-            File.delete(tmp_path)
+        # We can not be completely sure, that's the correct plist file, so we have to try
+        begin
+          # The XML file has to be properly unpacked first
+          tmp_path = "/tmp/deploytmp.plist"
+          File.write(tmp_path, zipfile.read(file))
+          system("plutil -convert xml1 #{tmp_path}")
+          result = Plist.parse_xml(tmp_path)
+          File.delete(tmp_path)
 
-            if result['CFBundleIdentifier'] or result['CFBundleVersion']
-              return result
-            end
-          rescue
-            # We don't really care, look for another XML file
+          if result['CFBundleIdentifier'] or result['CFBundleVersion']
+            return result
           end
+        rescue
+          # We don't really care, look for another XML file
         end
       end
 


### PR DESCRIPTION
As stated in [Issue 91](https://github.com/fastlane/fastlane_core/issues/91#issuecomment-174600610) the `fetch_info_plist_file` method in the `IpaFileAnalyser` sometimes fetched the wrong plist file.

I changed that to use glob to find the "Info.plist" file that is contained in an "*.app" directory.

What do you think about that change?
