### PR TITLE
Fix iTMS passwords containing certain special chars

### DIFF
--- a/lib/fastlane_core/itunes_transporter.rb
+++ b/lib/fastlane_core/itunes_transporter.rb
@@ -193,7 +193,7 @@ module FastlaneCore
         '"' + Helper.transporter_path + '"',
         "-m lookupMetadata",
         "-u \"#{username}\"",
-        "-p '#{escaped_password(password)}'",
+        "-p #{escaped_password(password)}",
         "-apple_id #{apple_id}",
         "-destination '#{destination}'"
       ].join(' ')
@@ -204,7 +204,7 @@ module FastlaneCore
         '"' + Helper.transporter_path + '"',
         "-m upload",
         "-u \"#{username}\"",
-        "-p '#{escaped_password(password)}'",
+        "-p #{escaped_password(password)}",
         "-f '#{source}'",
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         "-t 'Signiant'",


### PR DESCRIPTION
itunes_transporter.rb, lines [196](https://github.com/fastlane/fastlane_core/blob/master/lib/fastlane_core/itunes_transporter.rb#L196) and [207](https://github.com/fastlane/fastlane_core/blob/master/lib/fastlane_core/itunes_transporter.rb#L207), pass user's Apple ID password
to the iTMS Transporter escaped in single quotes:

```
-p '#{escaped_password(password)}'
```

The password is passed there after being processed through the
`escaped_password` function, which on the line [216](https://github.com/fastlane/fastlane_core/blob/master/lib/fastlane_core/itunes_transporter.rb#L216) of the same file does
nothing else then call Ruby's [`Shellwords.escape`
function](http://ruby-doc.org/stdlib-2.0.0/libdoc/shellwords/rdoc/Shellwords.html#method-c-escape),
which is an alias for the [`Shellwords.shellescape`
function](http://ruby-doc.org/stdlib-2.0.0/libdoc/shellwords/rdoc/Shellwords.html#method-c-shellescape). Quoting
from the documentation for `shellescape` (emphasis mine):

> Note that a resulted string **_should be used unquoted**_ and is not intended
> for use in double quotes **_nor in single quotes**_.

However what the documentation forbids, i.e. quoting the result in
single quotes, is exactly what the code is doing.

Solution is easy - as the same documentation sentence says, use the
result of the `shellescape` function (and its alias `escape`) "as is",
unquoted. So the correct usage is:

```
-p #{escaped_password(password)}
```

This commit makes exactly this change on 2 places - where building
upload and download command lines.

Since this way (using `Shellwords.shellescape` together with no quoting)
is also correct way for all other arguments, not just password, then if
fastlane uses externally executed commands in other places as well, I
suggest creating a function taking array of CLI args and taking care of
quoting them (or looking if Ruby already does not provide such function
itself).

After this change, `pilot upload` started working for me. Before, I was
hitting [this bug](https://github.com/fastlane/pilot/issues/128).

Other users have probably stumbled upon the issue in [another bug, this
time in deliver](https://github.com/fastlane/deliver/issues/312).

Disclaimer: I did not test this on **this** git checkout, but tested it
when making the same changes directly in my gems directory. I did not
test with deliver (as I have not had the opportunity to use it). I use
only `cert`, `sigh`, `gym` and `pilot` ATM, which work with this
change (though only `pilot` would need to use iTMS Transporter).
