### PR TITLE
Properly handle single-quotes in passwords.

### DIFF
--- a/lib/fastlane_core/itunes_transporter.rb
+++ b/lib/fastlane_core/itunes_transporter.rb
@@ -193,7 +193,7 @@ module FastlaneCore
         '"' + Helper.transporter_path + '"',
         "-m lookupMetadata",
         "-u \"#{username}\"",
-        "-p '#{escaped_password(password)}'",
+        "-p #{shell_escaped_password(password)}",
         "-apple_id #{apple_id}",
         "-destination '#{destination}'"
       ].join(' ')
@@ -204,7 +204,7 @@ module FastlaneCore
         '"' + Helper.transporter_path + '"',
         "-m upload",
         "-u \"#{username}\"",
-        "-p '#{escaped_password(password)}'",
+        "-p #{shell_escaped_password(password)}",
         "-f '#{source}'",
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         "-t 'Signiant'",
@@ -212,8 +212,19 @@ module FastlaneCore
       ].join(' ')
     end
 
-    def escaped_password(password)
-      Shellwords.escape(password)
+    def shell_escaped_password(password)
+      # because the shell handles passwords with single-quotes incorrectly, use gsub to replace ShellEscape'd single-quotes of this form:
+      #    \'
+      # with a sequence that wraps the escaped single-quote in double-quotes:
+      #    '"\'"'
+      # this allows us to properly handle passwords with single-quotes in them
+      # we use the 'do' version of gsub, because two-param version interprets the replace text as a pattern and does the wrong thing
+      password = Shellwords.escape(password).gsub("\\'") do
+        "'\"\\'\"'"
+      end
+
+      # wrap the fully-escaped password in single quotes, since the transporter expects a escaped password string (which must be single-quoted for the shell's benefit)
+      "'" + password + "'"
     end
   end
 end


### PR DESCRIPTION
This PR was inspired by this:
https://github.com/fastlane/fastlane_core/pull/30

After some experimentation, I determined that the only passwords that were not handled correctly by the transport binary were those containing single quotes, as they caused the shell to go into multi-line mode when calling iTMSTransporter, causing the upload to fail with no error.

To prove this, change your apple id password to:
`'Password1234'`
deliver will no longer be able to upload binaries to iTunes connect and, in fact, iTMSTransporter will never actually be called.

This code properly handles passwords with single quotes, as well as other shell-escaped characters: double-quotes, asterisk, bang, etc.
