### PR TITLE
Ignore configuration conflicts if one value of the configurations is nil

### DIFF
--- a/lib/fastlane_core/configuration/configuration.rb
+++ b/lib/fastlane_core/configuration/configuration.rb
@@ -84,6 +84,9 @@ module FastlaneCore
         index = @available_options.find_index { |item| item.key == current }
         current = @available_options[index]
 
+        # ignore conflicts because option value is nil
+        next if @values[current.key].nil?
+
         next if current.conflicting_options.nil?
 
         conflicts = current.conflicting_options & option_keys
@@ -92,6 +95,9 @@ module FastlaneCore
         conflicts.each do |conflicting_option_key|
           index = @available_options.find_index { |item| item.key == conflicting_option_key }
           conflicting_option = @available_options[index]
+
+          # ignore conflicts because because value of conflict option is nil
+          next if @values[conflicting_option.key].nil?
 
           if current.conflict_block
             begin


### PR DESCRIPTION
Options shouldn't have a conflict when one of the passed options is nil. For example this should be fine:

```
gym(workspace: "workspace-path",
      project: nil
  )
```
