### PR TITLE
Handle EIO error when running a command

### DIFF
--- a/lib/fastlane_core/command_executor.rb
+++ b/lib/fastlane_core/command_executor.rb
@@ -59,6 +59,9 @@ module FastlaneCore
             end
             Process.wait(pid)
           end
+        rescue Errno::EIO
+          # This is expected on some linux systems, that indicates that the subcommand finished
+          # and we kept trying to read, ignore it
         rescue => ex
           # This could happen when the environment is wrong:
           # > invalid byte sequence in US-ASCII (ArgumentError)


### PR DESCRIPTION
This should fix https://github.com/fastlane/screengrab/issues/73 which is caused by linux systems throwing `Errno::EIO` after all input is read.  [Relevant SO](http://stackoverflow.com/a/10306463).
