### PR TITLE
WWDR certificate install keychain search

### DIFF
--- a/lib/fastlane_core/cert_checker.rb
+++ b/lib/fastlane_core/cert_checker.rb
@@ -50,9 +50,7 @@ module FastlaneCore
         url = 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'
         filename = File.basename(url)
         keychain = wwdr_keychain
-        if not keychain.empty?
-          keychain.prepend("-k ")
-        end
+        keychain.prepend("-k ") unless keychain.empty?
         `curl -O #{url} && security import #{filename} #{keychain}`
         UI.user_error!("Could not install WWDR certificate") unless $?.success?
       end

--- a/lib/fastlane_core/cert_checker.rb
+++ b/lib/fastlane_core/cert_checker.rb
@@ -57,11 +57,20 @@ module FastlaneCore
     end
 
     def self.wwdr_keychain
-      keychains = `security list -d user`.split("\n")
-      if keychains.empty?
-        return ""
+      priority = [
+        "security list-keychains -d user",
+        "security default-keychain -d user"
+      ]
+      for command in priority
+        keychains = Helper.backticks(command, print: $verbose).split("\n")
+        unless keychains.empty?
+          # Select first keychain name from returned keychains list
+          keychain = keychains[0].strip.tr('"', '').split(File::SEPARATOR)[-1]
+          break
+        end
+        keychain = ""
       end
-      return keychains[0].strip.tr('"', '').split(File::SEPARATOR)[-1]
+      return keychain
     end
 
     def self.sha1_fingerprint(path)


### PR DESCRIPTION
Add logic to select correct user keychain based on `security list` output.

On a regular setup this will match `login.keychain`, but also allows systems that run with custom keychains (CI build systems for example that have no login) to not crash on this step.

Fixes https://github.com/fastlane/sigh/issues/264
Expands on code introduced in https://github.com/fastlane/fastlane_core/pull/35
