### PR TITLE
Add support for connected iOS devices

### DIFF
--- a/lib/fastlane_core.rb
+++ b/lib/fastlane_core.rb
@@ -16,7 +16,7 @@ require 'fastlane_core/command_executor'
 require 'fastlane_core/ipa_upload_package_builder'
 require 'fastlane_core/print_table'
 require 'fastlane_core/project'
-require 'fastlane_core/simulator'
+require 'fastlane_core/devices'
 require 'fastlane_core/crash_reporting/crash_reporting'
 require 'fastlane_core/ui/ui'
 


### PR DESCRIPTION
This relates to issue https://github.com/fastlane/scan/issues/53

This method of getting the uuid for a connected device uses system_profiler first to find actually connected usb devices then uses instruments to match the connected usb device and get the device name and iOS version. 

Since the device class was inside the simulator file i decided it would be best to change the class name to devices to make it more general class to handle both types of devices. The simulator class was left with a bridging method to maintain compatibility for fastlane tools until they are updated to support connected devices.
