### PR TITLE
Fix configuration file application of boolean values

### DIFF
--- a/lib/fastlane_core/configuration/config_item.rb
+++ b/lib/fastlane_core/configuration/config_item.rb
@@ -91,7 +91,7 @@ module FastlaneCore
         return value.to_f
       else
         # Special treatment if the user specififed true, false or YES, NO
-        # There is no boolean typoe, so we just do it here
+        # There is no boolean type, so we just do it here
         if %w(YES yes true TRUE).include?(value)
           return true
         elsif %w(NO no false FALSE).include?(value)

--- a/lib/fastlane_core/configuration/configuration_file.rb
+++ b/lib/fastlane_core/configuration/configuration_file.rb
@@ -32,10 +32,13 @@ module FastlaneCore
     def method_missing(method_sym, *arguments, &block)
       # First, check if the key is actually available
       if self.config.all_keys.include? method_sym
-        value = arguments.first || (block.call if block_given?) # this is either a block or a value
-        if value
-          self.config[method_sym] = value if self.config._values[method_sym].to_s.length == 0
-        end
+        # This silently prevents a value from having its value set more than once.
+        return unless self.config._values[method_sym].to_s.empty?
+
+        value = arguments.first
+        value = block.call if value.nil? && block_given?
+
+        self.config[method_sym] = value unless value.nil?
       else
         # We can't set this value, maybe the tool using this configuration system has its own
         # way of handling this block, as this might be a special block (e.g. ipa block) that's only

--- a/spec/configuration_file_spec.rb
+++ b/spec/configuration_file_spec.rb
@@ -7,6 +7,14 @@ describe FastlaneCore do
                                        description: "desc",
                                        is_string: false,
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :a_boolean,
+                                       description: "desc",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :another_boolean,
+                                       description: "desc",
+                                       is_string: false,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :ios_version,
                                        description: "desc",
                                        default_value: "123"),
@@ -47,6 +55,19 @@ describe FastlaneCore do
         config = FastlaneCore::Configuration.create(options, { app_identifier: "detlef.app.super" })
         config.load_configuration_file('ConfigFileEmpty')
         expect(config[:app_identifier]).to eq("detlef.app.super")
+      end
+
+      it "properly loads boolean values" do
+        config = FastlaneCore::Configuration.create(options, {})
+        config.load_configuration_file('ConfigFileBooleanValues')
+        expect(config[:a_boolean]).to be(false)
+        expect(config[:another_boolean]).to be(true)
+      end
+
+      it "ignores the same item being set after the first time" do
+        config = FastlaneCore::Configuration.create(options, {})
+        config.load_configuration_file('ConfigFileRepeatedValueSet')
+        expect(config[:app_identifier]).to eq('the.expected.value')
       end
 
       describe "Handling invalid broken configuration files" do

--- a/spec/fixtures/ConfigFileBooleanValues
+++ b/spec/fixtures/ConfigFileBooleanValues
@@ -1,0 +1,2 @@
+a_boolean false
+another_boolean true

--- a/spec/fixtures/ConfigFileRepeatedValueSet
+++ b/spec/fixtures/ConfigFileRepeatedValueSet
@@ -1,0 +1,2 @@
+app_identifier 'the.expected.value'
+app_identifier 'the.ignored.value'


### PR DESCRIPTION
Motivated by fastlane/gym#136 and the discoveries outlined in this [unsatisfactory work-around](https://github.com/fastlane/gym/issues/136#issuecomment-188416375).

It is not currently possible to specify a `false` value for a boolean config item through a configuration file. This adjusts the logic of `ConfigurationFile` to make things work as expected.

In addition to testing that, this also adds one more test to make clear an unexpected behavior that pre-existed this change. Namely, only the first value set for a config item will ever be used. Any subsequent values provided for a config item are silently ignored.
