### PR TITLE
Add tests that define the behavior of options parsing

### DIFF
--- a/spec/commander_generator_spec.rb
+++ b/spec/commander_generator_spec.rb
@@ -1,0 +1,225 @@
+describe FastlaneCore do
+  describe FastlaneCore::CommanderGenerator do
+    describe 'while options parsing' do
+      describe 'pass-through arguments' do
+        it 'captures those that are not command names or flags' do
+          # 'test' is the command name set up by TestCommanderProgram
+          stub_commander_runner_args(['test', 'other', '-b'])
+
+          program = TestCommanderProgram.run([
+            FastlaneCore::ConfigItem.new(key: :boolean_1,
+                                short_option: '-b',
+                                 description: 'Boolean 1',
+                                   is_string: false)
+          ])
+
+          expect(program.args).to eq(['other'])
+        end
+      end
+
+      describe 'String flags' do
+        let(:config_items) do
+          [
+            FastlaneCore::ConfigItem.new(key: :string_1,
+                                short_option: '-s',
+                                 description: 'String 1',
+                                   is_string: true)
+          ]
+        end
+
+        it 'raises MissingArgument for short flags with missing values' do
+          stub_commander_runner_args(['-s'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'raises MissingArgument for long flags with missing values' do
+          stub_commander_runner_args(['--string_1'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'captures the provided value for short flags' do
+          stub_commander_runner_args(['-s', 'value'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:string_1]).to eq('value')
+        end
+
+        it 'captures the provided value for long flags' do
+          stub_commander_runner_args(['--string_1', 'value'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:string_1]).to eq('value')
+        end
+      end
+
+      describe 'Integer flags' do
+        let(:config_items) do
+          [
+            FastlaneCore::ConfigItem.new(key: :integer_1,
+                                short_option: '-i',
+                                 description: 'Integer 1',
+                                   is_string: false,
+                                        type: Integer)
+          ]
+        end
+
+        it 'raises MissingArgument for short flags with missing values' do
+          stub_commander_runner_args(['-i'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'raises MissingArgument for long flags with missing values' do
+          stub_commander_runner_args(['--integer_1'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'captures the provided value for short flags' do
+          stub_commander_runner_args(['-i', '123'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:integer_1]).to eq(123)
+        end
+
+        it 'captures the provided value for long flags' do
+          stub_commander_runner_args(['--integer_1', '123'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:integer_1]).to eq(123)
+        end
+      end
+
+      describe 'Float flags' do
+        let(:config_items) do
+          [
+            FastlaneCore::ConfigItem.new(key: :float_1,
+                                short_option: '-f',
+                                 description: 'Float 1',
+                                   is_string: false,
+                                        type: Float)
+          ]
+        end
+
+        it 'raises MissingArgument for short flags with missing values' do
+          stub_commander_runner_args(['-f'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'raises MissingArgument for long flags with missing values' do
+          stub_commander_runner_args(['--float_1'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'captures the provided value for short flags' do
+          stub_commander_runner_args(['-f', '1.23'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:float_1]).to eq(1.23)
+        end
+
+        it 'captures the provided value for long flags' do
+          stub_commander_runner_args(['--float_1', '1.23'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:float_1]).to eq(1.23)
+        end
+      end
+
+      describe 'Boolean flags' do
+        let(:config_items) do
+          [
+            FastlaneCore::ConfigItem.new(key: :boolean_1,
+                                short_option: '-a',
+                                 description: 'Boolean 1',
+                                   is_string: false)
+          ]
+        end
+
+        it 'treats short flags with no data type as booleans with true values' do
+          stub_commander_runner_args(['-a'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:boolean_1]).to be(true)
+        end
+
+        it 'treats long flags with no data type as booleans with true values' do
+          stub_commander_runner_args(['--boolean_1'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:boolean_1]).to be(true)
+        end
+
+        # This outcome conflicts with much of our documentation, but this test captures the current behavior
+        it 'treats short flags with no data type as booleans with true values and ignores trailing values' do
+          stub_commander_runner_args(['-a', 'false'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:boolean_1]).to be(true)
+        end
+
+        # This outcome conflicts with much of our documentation, but this test captures the current behavior
+        it 'treats long flags with no data type as booleans with true values and ignores trailing values' do
+          stub_commander_runner_args(['--boolean_1', 'false'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:boolean_1]).to be(true)
+        end
+      end
+
+      describe 'Array flags' do
+        let(:config_items) do
+          [
+            FastlaneCore::ConfigItem.new(key: :array_1,
+                                short_option: '-a',
+                                 description: 'Array 1',
+                                   is_string: false,
+                                        type: Array)
+          ]
+        end
+
+        it 'raises MissingArgument for short flags with missing values' do
+          stub_commander_runner_args(['-a'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'raises MissingArgument for long flags with missing values' do
+          stub_commander_runner_args(['--array_1'])
+
+          expect { TestCommanderProgram.run(config_items) }.to raise_error(OptionParser::MissingArgument)
+        end
+
+        it 'captures the provided value for short flags' do
+          stub_commander_runner_args(['-a', 'a,b,c'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:array_1]).to eq(%w(a b c))
+        end
+
+        it 'captures the provided value for long flags' do
+          stub_commander_runner_args(['--array_1', 'a,b,c'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:array_1]).to eq(%w(a b c))
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'fastlane_core'
 
 require 'webmock/rspec'
 
+require 'test_commander_program'
+
 # This module is only used to check the environment is currently a testing env
 module SpecHelper
 end
@@ -25,4 +27,9 @@ ensure
     ENV.delete(k) unless old_vals.include?(k)
     ENV[k] = old_vals[k]
   end
+end
+
+def stub_commander_runner_args(args)
+  runner = Commander::Runner.new(args)
+  allow(Commander::Runner).to receive(:instance).and_return(runner)
 end

--- a/spec/test_commander_program.rb
+++ b/spec/test_commander_program.rb
@@ -1,0 +1,30 @@
+# Helper class that encapsulates the setup of a do-nothing Commander
+# program that captures the results of parsing command line options
+class TestCommanderProgram
+  include Commander::Methods
+
+  attr_accessor :args
+  attr_accessor :options
+
+  def self.run(config_items)
+    new(config_items).tap(&:run!)
+  end
+
+  def initialize(config_items)
+    # Sets up the global options in Commander whose behavior we want
+    # to be testing.
+    FastlaneCore::CommanderGenerator.new.generate(config_items)
+
+    program :version, '1.0'
+    program :description, 'Testing'
+
+    command :test do |c|
+      c.action do |args, options|
+        @args = args.dup
+        @options = options.__hash__.dup
+      end
+    end
+
+    default_command :test
+  end
+end


### PR DESCRIPTION
These tests exercise the round-trip of command line arguments through Commander and `OptionParser` as configured by `ConfigItem`s

I'd like to keep expanding these tests to have a solid regression suite before attempting to fix the problematic handling of boolean flags on the command line.
