### PR TITLE
Fix `CommanderGenerator` to not require short flags

### DIFF
--- a/lib/fastlane_core/configuration/commander_generator.rb
+++ b/lib/fastlane_core/configuration/commander_generator.rb
@@ -51,12 +51,19 @@ module FastlaneCore
         description = option.description
         description += " (#{option.env_name})" unless option.env_name.to_s.empty?
 
-        # This is the sole call to Commander to set up the option we've been building.
+        # We compact this array here to remove the short_switch variable if it is nil.
+        # Passing a nil value to global_option has been shown to create problems with
+        # option parsing!
+        #
+        # See: https://github.com/fastlane/fastlane_core/pull/89
         #
         # If we don't have a data type for this option, we tell it to act like a String.
         # This allows us to get a reasonable value for boolean options that can be
         # automatically coerced or otherwise handled by the ConfigItem for others.
-        global_option(short_switch, long_switch, (type || String), description)
+        args = [short_switch, long_switch, (type || String), description].compact
+
+        # This is the call to Commander to set up the option we've been building.
+        global_option(*args)
       end
     end
 

--- a/spec/commander_generator_spec.rb
+++ b/spec/commander_generator_spec.rb
@@ -1,6 +1,29 @@
 describe FastlaneCore do
   describe FastlaneCore::CommanderGenerator do
     describe 'while options parsing' do
+      describe '' do
+        it 'should not return `true` for String options with no short flag' do
+          config_items = [
+            FastlaneCore::ConfigItem.new(key: :long_option_only_string,
+                                 description: "desc",
+                                   is_string: true,
+                               default_value: "blah",
+                                    optional: true),
+            FastlaneCore::ConfigItem.new(key: :bool,
+                                 description: "desc",
+                               default_value: false,
+                                   is_string: false)
+          ]
+
+          stub_commander_runner_args(['--long_option_only_string', 'value', '--bool', 'false'])
+
+          program = TestCommanderProgram.run(config_items)
+
+          expect(program.options[:long_option_only_string]).to eq('value')
+          expect(program.options[:bool]).to eq('false')
+        end
+      end
+
       describe 'pass-through arguments' do
         it 'captures those that are not command names or flags' do
           # 'test' is the command name set up by TestCommanderProgram


### PR DESCRIPTION
Builds on the excellent test example from #89, adjusting the call to `Commander` to fix option parsing when no short flag is provided.
